### PR TITLE
Device-definition edit; Added frontend UI and document building.

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -110,6 +110,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	oracleApp.Get("/fleet/vehicles/:tokenID", genericProxyCtrl.Proxy)
 	oracleApp.Get("/fleet/vehicles/telemetry-info/:tokenID", genericProxyCtrl.Proxy)
 	oracleApp.Post("/fleet/vehicles/telemetry/:tokenID", genericProxyCtrl.Proxy)
+	oracleApp.Post("/fleet/vehicles/fetch", genericProxyCtrl.Proxy)
 	oracleApp.Get("/fleet/groups", genericProxyCtrl.Proxy)
 	oracleApp.Post("/fleet/groups", genericProxyCtrl.Proxy)
 	oracleApp.Get("/fleet/groups/:id", genericProxyCtrl.Proxy)

--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -72,10 +72,10 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	})
 	knownOracles := settings.GetOracles()
 
-    // Public tracking routes (no JWT, validated by share link UUID in backend)
-    app.Get("/tracking/:shareID", genericProxyCtrl.TrackingProxy)
-    app.Post("/tracking/:shareID/telemetry", genericProxyCtrl.TrackingProxy)
-    app.Post("/tracking/:shareID/trips", genericProxyCtrl.TrackingProxy)
+	// Public tracking routes (no JWT, validated by share link UUID in backend)
+	app.Get("/tracking/:shareID", genericProxyCtrl.TrackingProxy)
+	app.Post("/tracking/:shareID/telemetry", genericProxyCtrl.TrackingProxy)
+	app.Post("/tracking/:shareID/trips", genericProxyCtrl.TrackingProxy)
 
 	// these are general to the app, not oracle specific
 	app.Get("/public/settings", settingsCtrl.GetPublicSettings)
@@ -131,6 +131,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	oracleApp.Get("/fleet/report-templates", genericProxyCtrl.Proxy)
 
 	oracleApp.Get("/definitions/top", definitionsCtrl.TopDefinitions)
+	oracleApp.Post("/device-definitions/attest", genericProxyCtrl.Proxy)
 
 	// Mint new vehicle
 	oracleApp.Get("/vehicle/mint", vehiclesCtrl.GetVehiclesMintData)

--- a/web/src/elements/edit-device-definition-modal-element.ts
+++ b/web/src/elements/edit-device-definition-modal-element.ts
@@ -6,6 +6,7 @@ import {
   DeviceDefinitionAttribute,
   DeviceDefinitionDetail,
   IdentityService,
+  LatestDeviceDefinitionCloudEvent,
   ManufacturerOption,
 } from '@services/identity-service.ts';
 import { ApiService } from '@services/api-service.ts';
@@ -22,7 +23,7 @@ interface AttributeFieldConfig {
 const ATTRIBUTE_FIELDS: AttributeFieldConfig[] = [
   { key: 'powertrain_type', label: 'Powertrain Type', required: true, placeholder: 'Select powertrain type' },
   { key: 'fuel_type', label: 'Fuel Type', required: true, placeholder: 'Enter fuel type' },
-  { key: 'driven_wheels', label: 'Driven Wheels', type: 'number', placeholder: 'Enter driven wheels' },
+  { key: 'driven_wheels', label: 'Driven Wheels', placeholder: 'Select driven wheels' },
   { key: 'fuel_tank_capacity_gal', label: 'Fuel Tank Capacity (gal)', type: 'number', required: true, placeholder: 'Enter fuel tank capacity', allowDecimal: true },
   { key: 'mpg', label: 'MPG', type: 'number', placeholder: 'Enter MPG', allowDecimal: true },
   { key: 'mpg_city', label: 'MPG City', type: 'number', placeholder: 'Enter city MPG', allowDecimal: true },
@@ -54,6 +55,7 @@ const ATTRIBUTE_ALIASES: Record<string, string[]> = {
 @customElement('edit-device-definition-modal-element')
 export class EditDeviceDefinitionModalElement extends LitElement {
   private static cachedManufacturers: ManufacturerOption[] | null = null;
+  private static readonly DRIVEN_WHEEL_OPTIONS = ['FWD', 'RWD', 'AWD', '4WD'];
 
   static styles = [globalStyles, css`
     .modal-content {
@@ -149,9 +151,6 @@ export class EditDeviceDefinitionModalElement extends LitElement {
   @state() private attributeValues: Record<string, string> = {};
   @state() private extraAttributes: DeviceDefinitionAttribute[] = [];
   @state() private validationErrors: Record<string, string> = {};
-  @state() private generatedJson = '';
-
-  private lastLoadedDefinitionId = '';
 
   protected updated(changedProperties: Map<string | number | symbol, unknown>) {
     super.updated(changedProperties);
@@ -159,7 +158,6 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     const definitionChanged = changedProperties.has('deviceDefinitionId');
 
     if (showChanged && !this.show) {
-      this.generatedJson = '';
       return;
     }
 
@@ -223,11 +221,17 @@ export class EditDeviceDefinitionModalElement extends LitElement {
                         this.attributeValues[field.key] ?? '',
                         (value) => this.handleAttributeChange(field.key, value),
                         {
-                          type: field.key === 'powertrain_type' ? 'select' : (field.type ?? 'text'),
+                          type: field.key === 'powertrain_type' || field.key === 'driven_wheels'
+                            ? 'select'
+                            : (field.type ?? 'text'),
                           required: this.isFieldRequired(field.key) || isBatteryRequired,
                           hint: this.getFieldHint(field.key, isBatteryRequired),
                           placeholder: field.placeholder,
-                          options: field.key === 'powertrain_type' ? this.powertrainOptions : undefined,
+                          options: field.key === 'powertrain_type'
+                            ? this.powertrainOptions
+                            : field.key === 'driven_wheels'
+                              ? this.drivenWheelOptions
+                              : undefined,
                           disabled: this.isFieldDisabled(field.key),
                           allowDecimal: field.allowDecimal,
                         }
@@ -244,12 +248,6 @@ export class EditDeviceDefinitionModalElement extends LitElement {
                       </div>
                     ` : nothing}
                   </div>
-                  ${this.generatedJson ? html`
-                    <div class="section-title mt-16">${msg('Submission Response')}</div>
-                    <div class="form-group">
-                      <textarea class="json-preview" readonly .value=${this.generatedJson}></textarea>
-                    </div>
-                  ` : nothing}
                 `}
           </div>
           <div class="modal-footer">
@@ -286,17 +284,16 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     return this.getSelectOptions(['ICE', 'BEV', 'HEV'], this.attributeValues.powertrain_type || '');
   }
 
+  private get drivenWheelOptions(): string[] {
+    return this.getSelectOptions(
+      EditDeviceDefinitionModalElement.DRIVEN_WHEEL_OPTIONS,
+      this.attributeValues.driven_wheels || ''
+    );
+  }
+
   private async loadFormData() {
     if (!this.deviceDefinitionId) {
       this.errorMessage = msg('Device definition ID is missing.');
-      return;
-    }
-
-    if (
-      this.lastLoadedDefinitionId === this.deviceDefinitionId &&
-      this.currentDefinition &&
-      this.manufacturers.length > 0
-    ) {
       return;
     }
 
@@ -304,34 +301,37 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     this.errorMessage = '';
     this.successMessage = '';
     this.validationErrors = {};
-    this.generatedJson = '';
 
     try {
-      const [definition, manufacturers] = await Promise.all([
+      const [definition, latestCloudEvent, manufacturers] = await Promise.all([
         IdentityService.getInstance().getDeviceDefinitionById(this.deviceDefinitionId),
+        this.tokenDID
+          ? IdentityService.getInstance().getLatestDeviceDefinitionCloudEvent(this.tokenDID)
+          : Promise.resolve(null),
         EditDeviceDefinitionModalElement.cachedManufacturers
           ? Promise.resolve(EditDeviceDefinitionModalElement.cachedManufacturers)
           : IdentityService.getInstance().getManufacturers(),
       ]);
 
-      if (!definition) {
+      if (!definition && !latestCloudEvent?.data) {
         this.errorMessage = msg('Failed to load device definition.');
         this.loading = false;
         return;
       }
 
       EditDeviceDefinitionModalElement.cachedManufacturers = manufacturers;
-      this.lastLoadedDefinitionId = this.deviceDefinitionId;
-      this.currentDefinition = definition;
       this.manufacturers = manufacturers.sort((a, b) => a.name.localeCompare(b.name));
+
+      const resolvedDefinition = this.mergeDefinitionData(definition, latestCloudEvent);
+      this.currentDefinition = resolvedDefinition;
       this.manufacturer = this.normalizeSelectValue(
-        definition.manufacturer?.name || '',
+        resolvedDefinition.manufacturer?.name || '',
         this.manufacturers.map((item) => item.name)
       );
-      this.model = definition.model || '';
-      this.year = definition.year != null ? String(definition.year) : '';
+      this.model = resolvedDefinition.model || '';
+      this.year = resolvedDefinition.year != null ? String(resolvedDefinition.year) : '';
 
-      const normalizedAttributes = this.normalizeAttributes(definition.attributes ?? []);
+      const normalizedAttributes = this.normalizeAttributes(resolvedDefinition.attributes ?? []);
       this.attributeValues = normalizedAttributes.values;
       this.extraAttributes = normalizedAttributes.extra;
     } catch (error) {
@@ -354,13 +354,60 @@ export class EditDeviceDefinitionModalElement extends LitElement {
       if (key) {
         values[key] = key === 'powertrain_type'
           ? this.normalizeSelectValue(attribute.value ?? '', ['ICE', 'BEV', 'HEV'])
-          : attribute.value ?? '';
+          : key === 'driven_wheels'
+            ? this.normalizeSelectValue(attribute.value ?? '', EditDeviceDefinitionModalElement.DRIVEN_WHEEL_OPTIONS)
+            : attribute.value ?? '';
       } else {
         extra.push(attribute);
       }
     });
 
     return { values, extra };
+  }
+
+  private mergeDefinitionData(
+    identityDefinition: DeviceDefinitionDetail | null,
+    latestCloudEvent: LatestDeviceDefinitionCloudEvent | null
+  ): DeviceDefinitionDetail {
+    const latestDefinition = latestCloudEvent?.data;
+    const mergedIdentityDefinition = identityDefinition ?? {};
+
+    return {
+      model: latestDefinition?.model ?? mergedIdentityDefinition.model,
+      year: latestDefinition?.year ?? mergedIdentityDefinition.year,
+      manufacturer: {
+        name: latestDefinition?.manufacturer?.name ?? mergedIdentityDefinition.manufacturer?.name,
+      },
+      deviceDefinitionId: latestDefinition?.deviceDefinitionId ?? mergedIdentityDefinition.deviceDefinitionId,
+      deviceType: latestDefinition?.deviceType ?? mergedIdentityDefinition.deviceType,
+      attributes: this.mergeAttributes(
+        mergedIdentityDefinition.attributes ?? [],
+        latestDefinition?.attributes ?? []
+      ),
+    };
+  }
+
+  private mergeAttributes(
+    fallbackAttributes: DeviceDefinitionAttribute[],
+    latestAttributes: DeviceDefinitionAttribute[]
+  ): DeviceDefinitionAttribute[] {
+    const merged = new Map<string, DeviceDefinitionAttribute>();
+
+    fallbackAttributes.forEach((attribute) => {
+      const key = (attribute.name || '').trim();
+      if (key) {
+        merged.set(key, { ...attribute });
+      }
+    });
+
+    latestAttributes.forEach((attribute) => {
+      const key = (attribute.name || '').trim();
+      if (key) {
+        merged.set(key, { ...attribute });
+      }
+    });
+
+    return Array.from(merged.values());
   }
 
   private getCanonicalAttributeKey(name: string): string | undefined {
@@ -451,6 +498,10 @@ export class EditDeviceDefinitionModalElement extends LitElement {
   private sanitizeAttributeValue(key: string, value: string): string {
     if (key === 'powertrain_type') {
       return value.trim().toUpperCase();
+    }
+
+    if (key === 'driven_wheels') {
+      return this.normalizeSelectValue(value, EditDeviceDefinitionModalElement.DRIVEN_WHEEL_OPTIONS);
     }
 
     if (key === 'fuel_type') {
@@ -567,6 +618,14 @@ export class EditDeviceDefinitionModalElement extends LitElement {
       if (field.key === 'fuel_type' && value && /^\d+(\.\d+)?$/.test(value)) {
         errors[field.key] = msg('Fuel Type must include letters.');
       }
+
+      if (
+        field.key === 'driven_wheels' &&
+        value &&
+        !EditDeviceDefinitionModalElement.DRIVEN_WHEEL_OPTIONS.includes(value)
+      ) {
+        errors[field.key] = msg('Driven Wheels must be one of FWD, RWD, AWD, or 4WD.');
+      }
     });
 
     this.validationErrors = errors;
@@ -578,7 +637,6 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     this.errorMessage = '';
     this.successMessage = '';
     this.validationErrors = {};
-    this.generatedJson = '';
     this.dispatchEvent(new CustomEvent('modal-closed', {
       bubbles: true,
       composed: true,
@@ -589,7 +647,6 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     if (!this.validateForm()) {
       this.errorMessage = msg('Please fix the highlighted fields.');
       this.successMessage = '';
-      this.generatedJson = '';
       return;
     }
 
@@ -600,7 +657,6 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     try {
       if (!this.tokenDID.trim()) {
         this.errorMessage = msg('Vehicle tokenDID is missing.');
-        this.generatedJson = '';
         return;
       }
 
@@ -620,16 +676,33 @@ export class EditDeviceDefinitionModalElement extends LitElement {
 
       if (!response.success) {
         this.errorMessage = response.error || msg('Failed to submit device definition update.');
-        this.generatedJson = '';
         return;
       }
 
-      this.generatedJson = JSON.stringify(response.data ?? {}, null, 2);
+      const latestCloudEvent = this.tokenDID
+        ? await IdentityService.getInstance().getLatestDeviceDefinitionCloudEvent(this.tokenDID)
+        : null;
+
+      if (latestCloudEvent?.data) {
+        const refreshedDefinition = this.mergeDefinitionData(this.currentDefinition ?? null, latestCloudEvent);
+        this.currentDefinition = refreshedDefinition;
+        this.manufacturer = this.normalizeSelectValue(
+          refreshedDefinition.manufacturer?.name || '',
+          this.manufacturers.map((item) => item.name)
+        );
+        this.model = refreshedDefinition.model || '';
+        this.year = refreshedDefinition.year != null ? String(refreshedDefinition.year) : '';
+
+        const normalizedAttributes = this.normalizeAttributes(refreshedDefinition.attributes ?? []);
+        this.attributeValues = normalizedAttributes.values;
+        this.extraAttributes = normalizedAttributes.extra;
+      }
+
       this.successMessage = msg('Device definition update submitted.');
       this.dispatchEvent(new CustomEvent('device-definition-update-requested', {
         detail: {
           request: payload,
-          response: response.data,
+          response: latestCloudEvent ?? response.data,
         },
         bubbles: true,
         composed: true,
@@ -687,7 +760,12 @@ export class EditDeviceDefinitionModalElement extends LitElement {
     const editableAttributes = ATTRIBUTE_FIELDS
       .map((field) => ({
         name: field.key,
-        value: (this.attributeValues[field.key] ?? '').trim(),
+        value: field.key === 'driven_wheels'
+          ? this.normalizeSelectValue(
+              (this.attributeValues[field.key] ?? '').trim(),
+              EditDeviceDefinitionModalElement.DRIVEN_WHEEL_OPTIONS
+            )
+          : (this.attributeValues[field.key] ?? '').trim(),
       }))
       .filter((attribute) => attribute.value !== '' || existingAttributeKeys.has(attribute.name));
 

--- a/web/src/elements/edit-device-definition-modal-element.ts
+++ b/web/src/elements/edit-device-definition-modal-element.ts
@@ -1,0 +1,696 @@
+import { html, nothing, LitElement, css } from 'lit';
+import { msg } from '@lit/localize';
+import { customElement, property, state } from 'lit/decorators.js';
+import { globalStyles } from '../global-styles.ts';
+import {
+  DeviceDefinitionAttribute,
+  DeviceDefinitionDetail,
+  IdentityService,
+  ManufacturerOption,
+} from '@services/identity-service.ts';
+import { ApiService } from '@services/api-service.ts';
+
+interface AttributeFieldConfig {
+  key: string;
+  label: string;
+  type?: 'text' | 'number';
+  required?: boolean;
+  placeholder?: string;
+  allowDecimal?: boolean;
+}
+
+const ATTRIBUTE_FIELDS: AttributeFieldConfig[] = [
+  { key: 'powertrain_type', label: 'Powertrain Type', required: true, placeholder: 'Select powertrain type' },
+  { key: 'fuel_type', label: 'Fuel Type', required: true, placeholder: 'Enter fuel type' },
+  { key: 'driven_wheels', label: 'Driven Wheels', type: 'number', placeholder: 'Enter driven wheels' },
+  { key: 'fuel_tank_capacity_gal', label: 'Fuel Tank Capacity (gal)', type: 'number', required: true, placeholder: 'Enter fuel tank capacity', allowDecimal: true },
+  { key: 'mpg', label: 'MPG', type: 'number', placeholder: 'Enter MPG', allowDecimal: true },
+  { key: 'mpg_city', label: 'MPG City', type: 'number', placeholder: 'Enter city MPG', allowDecimal: true },
+  { key: 'mpg_highway', label: 'MPG Highway', type: 'number', placeholder: 'Enter highway MPG', allowDecimal: true },
+  { key: 'number_of_doors', label: 'Number of Doors', type: 'number', placeholder: 'Enter number of doors' },
+  { key: 'generation', label: 'Generation', type: 'number', placeholder: 'Enter generation' },
+  { key: 'battery_capacity_kwh', label: 'Battery Capacity (KWh)', type: 'number', placeholder: 'Enter battery capacity', allowDecimal: true },
+  { key: 'base_msrp', label: 'Base MSRP', type: 'number', placeholder: 'Enter base MSRP', allowDecimal: true },
+  { key: 'manufacturer_code', label: 'Manufacturer Code', placeholder: 'Enter manufacturer code' },
+  { key: 'wheelbase', label: 'Wheelbase', placeholder: 'Enter wheelbase' },
+];
+
+const ATTRIBUTE_ALIASES: Record<string, string[]> = {
+  powertrain_type: ['powertrainType'],
+  fuel_type: ['fuelType'],
+  driven_wheels: ['drivenWheels'],
+  fuel_tank_capacity_gal: ['fuelTankCapacityGal'],
+  mpg: [],
+  mpg_city: ['mpgCity'],
+  mpg_highway: ['mpgHighway'],
+  number_of_doors: ['numberOfDoors'],
+  generation: [],
+  battery_capacity_kwh: ['batteryCapacityKwh'],
+  base_msrp: ['baseMsrp'],
+  manufacturer_code: ['manufacturerCode'],
+  wheelbase: [],
+};
+
+@customElement('edit-device-definition-modal-element')
+export class EditDeviceDefinitionModalElement extends LitElement {
+  private static cachedManufacturers: ManufacturerOption[] | null = null;
+
+  static styles = [globalStyles, css`
+    .modal-content {
+      max-width: 880px;
+      display: flex;
+      flex-direction: column;
+      max-height: 90vh;
+    }
+
+    .modal-body {
+      flex: 1;
+      overflow-y: auto;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .section-title {
+      font-weight: bold;
+      margin-bottom: 12px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid #ccc;
+    }
+
+    .field-hint {
+      margin-top: 4px;
+      font-size: 12px;
+      color: #666;
+    }
+
+    .required {
+      color: #c00;
+    }
+
+    .readonly-value {
+      padding: 8px 10px;
+      border: 1px solid #ccc;
+      background: #f8f8f8;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+    }
+
+    .full-width {
+      grid-column: 1 / -1;
+    }
+
+    .json-preview {
+      width: 100%;
+      min-height: 220px;
+      resize: vertical;
+      font-family: monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      white-space: pre;
+    }
+
+    .disabled-field {
+      background: #f0f0f0;
+      color: #777;
+      border-color: #ccc;
+      cursor: not-allowed;
+    }
+
+    @media (max-width: 900px) {
+      .form-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  `];
+
+  @property({ attribute: true, type: Boolean })
+  public show = false;
+
+  @property({ attribute: false, type: String })
+  public deviceDefinitionId = '';
+
+  @property({ attribute: false, type: String })
+  public tokenDID = '';
+
+  @state() private loading = false;
+  @state() private saving = false;
+  @state() private errorMessage = '';
+  @state() private successMessage = '';
+  @state() private manufacturers: ManufacturerOption[] = [];
+  @state() private manufacturer = '';
+  @state() private model = '';
+  @state() private year = '';
+  @state() private currentDefinition?: DeviceDefinitionDetail;
+  @state() private attributeValues: Record<string, string> = {};
+  @state() private extraAttributes: DeviceDefinitionAttribute[] = [];
+  @state() private validationErrors: Record<string, string> = {};
+  @state() private generatedJson = '';
+
+  private lastLoadedDefinitionId = '';
+
+  protected updated(changedProperties: Map<string | number | symbol, unknown>) {
+    super.updated(changedProperties);
+    const showChanged = changedProperties.has('show');
+    const definitionChanged = changedProperties.has('deviceDefinitionId');
+
+    if (showChanged && !this.show) {
+      this.generatedJson = '';
+      return;
+    }
+
+    if ((showChanged || definitionChanged) && this.show) {
+      this.loadFormData();
+    }
+  }
+
+  render() {
+    if (!this.show) {
+      return nothing;
+    }
+
+    return html`
+      <div class="modal-overlay" @click=${this.handleCancel}>
+        <div class="modal-content" @click=${(e: Event) => e.stopPropagation()}>
+          <div class="modal-header">
+            <h3>${msg('Update Device Definition')}</h3>
+            <button type="button" class="modal-close" @click=${this.handleCancel}>×</button>
+          </div>
+          <div class="modal-body">
+            ${this.errorMessage ? html`<div class="alert alert-error">${this.errorMessage}</div>` : nothing}
+            ${this.successMessage ? html`<div class="alert alert-success">${this.successMessage}</div>` : nothing}
+            ${this.loading
+              ? html`<div>${msg('Loading device definition...')}</div>`
+              : html`
+                  <div class="section-title">${msg('Vehicle Identity')}</div>
+                  <div class="form-grid mb-24">
+                    ${this.renderTextField('manufacturer', msg('Manufacturer'), this.manufacturer, (value) => (this.manufacturer = value), {
+                      type: 'select',
+                      required: true,
+                      options: this.manufacturerOptions,
+                      placeholder: 'Select manufacturer',
+                    })}
+                    ${this.renderTextField('model', msg('Model'), this.model, (value) => (this.model = value), {
+                      required: true,
+                      placeholder: 'Enter model',
+                    })}
+                    ${this.renderTextField('year', msg('Year'), this.year, (value) => (this.year = this.sanitizeNumericInput(value, false, 4)), {
+                      type: 'number',
+                      required: true,
+                      placeholder: 'Enter year',
+                    })}
+                    <div class="form-group">
+                      <label class="form-label">${msg('Definition ID')}</label>
+                      <div class="readonly-value">${this.buildDeviceDefinitionId()}</div>
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">${msg('Device Type')}</label>
+                      <div class="readonly-value">${this.currentDefinition?.deviceType || '-'}</div>
+                    </div>
+                  </div>
+
+                  <div class="section-title">${msg('Vehicle Attributes')}</div>
+                  <div class="form-grid">
+                    ${ATTRIBUTE_FIELDS.map((field) => {
+                      const isBatteryRequired = field.key === 'battery_capacity_kwh' && this.isBatteryRequired;
+                      return this.renderTextField(
+                        field.key,
+                        msg(field.label),
+                        this.attributeValues[field.key] ?? '',
+                        (value) => this.handleAttributeChange(field.key, value),
+                        {
+                          type: field.key === 'powertrain_type' ? 'select' : (field.type ?? 'text'),
+                          required: this.isFieldRequired(field.key) || isBatteryRequired,
+                          hint: this.getFieldHint(field.key, isBatteryRequired),
+                          placeholder: field.placeholder,
+                          options: field.key === 'powertrain_type' ? this.powertrainOptions : undefined,
+                          disabled: this.isFieldDisabled(field.key),
+                          allowDecimal: field.allowDecimal,
+                        }
+                      );
+                    })}
+                    ${this.extraAttributes.length > 0 ? html`
+                      <div class="form-group full-width">
+                        <label class="form-label">${msg('Additional Attributes')}</label>
+                        <div class="readonly-value" style="display:block;">
+                          ${this.extraAttributes.map((attribute) => html`
+                            <div><strong>${attribute.name || '-'}</strong>: ${attribute.value || '-'}</div>
+                          `)}
+                        </div>
+                      </div>
+                    ` : nothing}
+                  </div>
+                  ${this.generatedJson ? html`
+                    <div class="section-title mt-16">${msg('Submission Response')}</div>
+                    <div class="form-group">
+                      <textarea class="json-preview" readonly .value=${this.generatedJson}></textarea>
+                    </div>
+                  ` : nothing}
+                `}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn" @click=${this.handleCancel} ?disabled=${this.saving}>
+              ${msg('Cancel')}
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary ${this.saving ? 'processing' : ''}"
+              @click=${this.handleSubmit}
+              ?disabled=${this.loading || this.saving}
+            >
+              ${msg('Submit')}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private get isBatteryRequired(): boolean {
+    return (this.attributeValues.powertrain_type || '').trim().toUpperCase() === 'BEV';
+  }
+
+  private get isBev(): boolean {
+    return (this.attributeValues.powertrain_type || '').trim().toUpperCase() === 'BEV';
+  }
+
+  private get manufacturerOptions(): string[] {
+    return this.getSelectOptions(this.manufacturers.map((item) => item.name), this.manufacturer);
+  }
+
+  private get powertrainOptions(): string[] {
+    return this.getSelectOptions(['ICE', 'BEV', 'HEV'], this.attributeValues.powertrain_type || '');
+  }
+
+  private async loadFormData() {
+    if (!this.deviceDefinitionId) {
+      this.errorMessage = msg('Device definition ID is missing.');
+      return;
+    }
+
+    if (
+      this.lastLoadedDefinitionId === this.deviceDefinitionId &&
+      this.currentDefinition &&
+      this.manufacturers.length > 0
+    ) {
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+    this.successMessage = '';
+    this.validationErrors = {};
+    this.generatedJson = '';
+
+    try {
+      const [definition, manufacturers] = await Promise.all([
+        IdentityService.getInstance().getDeviceDefinitionById(this.deviceDefinitionId),
+        EditDeviceDefinitionModalElement.cachedManufacturers
+          ? Promise.resolve(EditDeviceDefinitionModalElement.cachedManufacturers)
+          : IdentityService.getInstance().getManufacturers(),
+      ]);
+
+      if (!definition) {
+        this.errorMessage = msg('Failed to load device definition.');
+        this.loading = false;
+        return;
+      }
+
+      EditDeviceDefinitionModalElement.cachedManufacturers = manufacturers;
+      this.lastLoadedDefinitionId = this.deviceDefinitionId;
+      this.currentDefinition = definition;
+      this.manufacturers = manufacturers.sort((a, b) => a.name.localeCompare(b.name));
+      this.manufacturer = this.normalizeSelectValue(
+        definition.manufacturer?.name || '',
+        this.manufacturers.map((item) => item.name)
+      );
+      this.model = definition.model || '';
+      this.year = definition.year != null ? String(definition.year) : '';
+
+      const normalizedAttributes = this.normalizeAttributes(definition.attributes ?? []);
+      this.attributeValues = normalizedAttributes.values;
+      this.extraAttributes = normalizedAttributes.extra;
+    } catch (error) {
+      this.errorMessage = msg('Failed to load device definition.');
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private normalizeAttributes(attributes: DeviceDefinitionAttribute[]) {
+    const values: Record<string, string> = {};
+    const extra: DeviceDefinitionAttribute[] = [];
+
+    ATTRIBUTE_FIELDS.forEach((field) => {
+      values[field.key] = '';
+    });
+
+    attributes.forEach((attribute) => {
+      const key = this.getCanonicalAttributeKey(attribute.name || '');
+      if (key) {
+        values[key] = key === 'powertrain_type'
+          ? this.normalizeSelectValue(attribute.value ?? '', ['ICE', 'BEV', 'HEV'])
+          : attribute.value ?? '';
+      } else {
+        extra.push(attribute);
+      }
+    });
+
+    return { values, extra };
+  }
+
+  private getCanonicalAttributeKey(name: string): string | undefined {
+    const normalized = name.replace(/[_-\s]/g, '').toLowerCase();
+    return ATTRIBUTE_FIELDS.find((field) => {
+      const candidates = [field.key, ...(ATTRIBUTE_ALIASES[field.key] || [])];
+      return candidates.some((candidate) => candidate.replace(/[_-\s]/g, '').toLowerCase() === normalized);
+    })?.key;
+  }
+
+  private renderTextField(
+    fieldKey: string,
+    label: string,
+    value: string,
+    onChange: (value: string) => void,
+    options: {
+      type?: 'text' | 'number' | 'select';
+      required?: boolean;
+      hint?: string;
+      options?: string[];
+      placeholder?: string;
+      disabled?: boolean;
+      allowDecimal?: boolean;
+    } = {}
+  ) {
+    const normalizedSelectValue = options.type === 'select'
+      ? this.normalizeSelectValue(value, options.options ?? [])
+      : value;
+
+    return html`
+      <div class="form-group">
+        <label class="form-label">
+          ${label}${options.required ? html` <span class="required">*</span>` : nothing}
+        </label>
+        ${options.type === 'select'
+          ? html`
+              <select
+                class=${options.disabled ? 'disabled-field' : ''}
+                .value=${normalizedSelectValue}
+                ?disabled=${options.disabled}
+                @change=${(e: Event) => onChange((e.target as HTMLSelectElement).value)}
+              >
+                <option value="" ?selected=${!normalizedSelectValue}>${msg(options.placeholder || 'Select')}</option>
+                ${(options.options ?? []).map((option) => html`
+                  <option value=${option} ?selected=${option === normalizedSelectValue}>${option}</option>
+                `)}
+              </select>
+            `
+          : html`
+              <input
+                type="text"
+                class=${options.disabled ? 'disabled-field' : ''}
+                inputmode=${options.type === 'number' ? (options.allowDecimal ? 'decimal' : 'numeric') : 'text'}
+                .placeholder=${msg(options.placeholder || '')}
+                .value=${value}
+                ?disabled=${options.disabled}
+                @input=${(e: Event) => onChange((e.target as HTMLInputElement).value)}
+              />
+            `}
+        ${this.validationErrors[fieldKey] ? html`<div class="field-hint" style="color:#c00;">${this.validationErrors[fieldKey]}</div>` : nothing}
+        ${options.hint && !this.validationErrors[fieldKey] ? html`<div class="field-hint">${options.hint}</div>` : nothing}
+      </div>
+    `;
+  }
+
+  private handleAttributeChange(key: string, value: string) {
+    const nextValue = this.sanitizeAttributeValue(key, value);
+    this.attributeValues = {
+      ...this.attributeValues,
+      [key]: nextValue,
+    };
+
+    if (this.validationErrors[key]) {
+      const nextErrors = { ...this.validationErrors };
+      delete nextErrors[key];
+      this.validationErrors = nextErrors;
+    }
+
+    if (key === 'powertrain_type') {
+      const nextErrors = { ...this.validationErrors };
+      delete nextErrors.battery_capacity_kwh;
+      delete nextErrors.fuel_tank_capacity_gal;
+      delete nextErrors.fuel_type;
+      this.validationErrors = nextErrors;
+    }
+  }
+
+  private sanitizeAttributeValue(key: string, value: string): string {
+    if (key === 'powertrain_type') {
+      return value.trim().toUpperCase();
+    }
+
+    if (key === 'fuel_type') {
+      return value;
+    }
+
+    const field = ATTRIBUTE_FIELDS.find((item) => item.key === key);
+    if (field?.type === 'number') {
+      return this.sanitizeNumericInput(value, Boolean(field.allowDecimal));
+    }
+
+    return value;
+  }
+
+  private sanitizeNumericInput(value: string, allowDecimal: boolean, maxLength?: number): string {
+    let nextValue = value.replace(allowDecimal ? /[^0-9.]/g : /[^0-9]/g, '');
+    if (allowDecimal) {
+      const firstDecimalIndex = nextValue.indexOf('.');
+      if (firstDecimalIndex !== -1) {
+        nextValue =
+          nextValue.slice(0, firstDecimalIndex + 1) +
+          nextValue.slice(firstDecimalIndex + 1).replace(/\./g, '');
+      }
+    }
+    if (maxLength) {
+      nextValue = nextValue.slice(0, maxLength);
+    }
+    return nextValue;
+  }
+
+  private isFieldDisabled(fieldKey: string): boolean {
+    if (fieldKey === 'battery_capacity_kwh') {
+      return !this.isBev;
+    }
+    if (fieldKey === 'fuel_tank_capacity_gal') {
+      return this.isBev;
+    }
+    return false;
+  }
+
+  private isFieldRequired(fieldKey: string): boolean {
+    if (fieldKey === 'powertrain_type') {
+      return true;
+    }
+    if (this.isBev) {
+      return fieldKey === 'battery_capacity_kwh';
+    }
+    return fieldKey === 'fuel_type' || fieldKey === 'fuel_tank_capacity_gal';
+  }
+
+  private getFieldHint(fieldKey: string, isBatteryRequired: boolean): string {
+    if (fieldKey === 'battery_capacity_kwh' && !this.isBev) {
+      return msg('Only applicable for BEV vehicles.');
+    }
+    if (fieldKey === 'fuel_tank_capacity_gal' && this.isBev) {
+      return msg('Not applicable for BEV vehicles.');
+    }
+    if (fieldKey === 'battery_capacity_kwh' && isBatteryRequired) {
+      return msg('Required for BEV vehicles.');
+    }
+    return '';
+  }
+
+  private normalizeSelectValue(value: string, options: string[]): string {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+      return '';
+    }
+
+    const matchedOption = options.find((option) => option.toLowerCase() === trimmedValue.toLowerCase());
+    return matchedOption ?? trimmedValue;
+  }
+
+  private getSelectOptions(options: string[], currentValue: string): string[] {
+    const normalizedCurrentValue = this.normalizeSelectValue(currentValue, options);
+    return normalizedCurrentValue && !options.some((option) => option === normalizedCurrentValue)
+      ? [...options, normalizedCurrentValue]
+      : options;
+  }
+
+  private validateForm(): boolean {
+    const errors: Record<string, string> = {};
+    const numericFields = new Set(['year', 'fuel_tank_capacity_gal', 'mpg', 'mpg_city', 'mpg_highway', 'number_of_doors', 'battery_capacity_kwh']);
+
+    if (!this.manufacturer.trim()) {
+      errors.manufacturer = msg('Manufacturer is required.');
+    }
+    if (!this.model.trim()) {
+      errors.model = msg('Model is required.');
+    }
+    if (!this.year.trim()) {
+      errors.year = msg('Year is required.');
+    } else if (!/^\d{4}$/.test(this.year.trim())) {
+      errors.year = msg('Year must be a 4-digit number.');
+    }
+
+    ATTRIBUTE_FIELDS.forEach((field) => {
+      if (this.isFieldDisabled(field.key)) {
+        return;
+      }
+
+      const value = (this.attributeValues[field.key] || '').trim();
+      const required = this.isFieldRequired(field.key);
+
+      if (required && !value) {
+        errors[field.key] = msg(`${field.label} is required.`);
+        return;
+      }
+
+      if (value && (field.type === 'number' || numericFields.has(field.key)) && Number.isNaN(Number(value))) {
+        errors[field.key] = msg(`${field.label} must be numeric.`);
+      }
+
+      if (field.key === 'fuel_type' && value && /^\d+(\.\d+)?$/.test(value)) {
+        errors[field.key] = msg('Fuel Type must include letters.');
+      }
+    });
+
+    this.validationErrors = errors;
+    return Object.values(errors).filter(Boolean).length === 0;
+  }
+
+  private handleCancel() {
+    this.show = false;
+    this.errorMessage = '';
+    this.successMessage = '';
+    this.validationErrors = {};
+    this.generatedJson = '';
+    this.dispatchEvent(new CustomEvent('modal-closed', {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private async handleSubmit() {
+    if (!this.validateForm()) {
+      this.errorMessage = msg('Please fix the highlighted fields.');
+      this.successMessage = '';
+      this.generatedJson = '';
+      return;
+    }
+
+    this.saving = true;
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    try {
+      if (!this.tokenDID.trim()) {
+        this.errorMessage = msg('Vehicle tokenDID is missing.');
+        this.generatedJson = '';
+        return;
+      }
+
+      const definitionDocument = this.buildDefinitionDocument();
+      const payload = {
+        tokenDID: this.tokenDID,
+        document: definitionDocument,
+      };
+      const response = await ApiService.getInstance().callApi(
+        'POST',
+        '/device-definitions/attest',
+        payload,
+        true,
+        true,
+        true
+      );
+
+      if (!response.success) {
+        this.errorMessage = response.error || msg('Failed to submit device definition update.');
+        this.generatedJson = '';
+        return;
+      }
+
+      this.generatedJson = JSON.stringify(response.data ?? {}, null, 2);
+      this.successMessage = msg('Device definition update submitted.');
+      this.dispatchEvent(new CustomEvent('device-definition-update-requested', {
+        detail: {
+          request: payload,
+          response: response.data,
+        },
+        bubbles: true,
+        composed: true,
+      }));
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  private buildDefinitionDocument() {
+    return {
+      model: this.model.trim(),
+      year: Number(this.year),
+      manufacturer: {
+        name: this.manufacturer.trim(),
+      },
+      deviceDefinitionId: this.buildDeviceDefinitionId(),
+      deviceType: 'vehicle',
+      attributes: this.buildAttributePayload(),
+    };
+  }
+
+  private buildDeviceDefinitionId(): string {
+    const manufacturerSlug = this.slugifyDefinitionPart(this.manufacturer);
+    const modelSlug = this.slugifyDefinitionPart(this.model);
+    const yearPart = this.year.trim();
+
+    if (manufacturerSlug && modelSlug && yearPart) {
+      return `${manufacturerSlug}_${modelSlug}_${yearPart}`;
+    }
+
+    return this.currentDefinition?.deviceDefinitionId || this.deviceDefinitionId;
+  }
+
+  private slugifyDefinitionPart(value: string): string {
+    return value
+      .trim()
+      .toLocaleLowerCase('en')
+      .normalize('NFD')
+      .replace(/\p{M}/gu, '')
+      .replace(/ /g, '-')
+      .replace(/_/g, '-')
+      .replace(/\//g, '-')
+      .replace(/\./g, '-')
+      .replace(/'/g, '-');
+  }
+
+  private buildAttributePayload(): DeviceDefinitionAttribute[] {
+    const existingAttributeKeys = new Set(
+      (this.currentDefinition?.attributes ?? [])
+        .map((attribute) => this.getCanonicalAttributeKey(attribute.name || ''))
+        .filter((key): key is string => Boolean(key))
+    );
+
+    const editableAttributes = ATTRIBUTE_FIELDS
+      .map((field) => ({
+        name: field.key,
+        value: (this.attributeValues[field.key] ?? '').trim(),
+      }))
+      .filter((attribute) => attribute.value !== '' || existingAttributeKeys.has(attribute.name));
+
+    return [...editableAttributes, ...this.extraAttributes];
+  }
+}

--- a/web/src/elements/index.ts
+++ b/web/src/elements/index.ts
@@ -14,4 +14,5 @@ export * from "./create-fleet-group-modal-element.ts";
 export * from "./confirm-modal-element.ts";
 export * from "./manage-group-vehicles-modal-element.ts";
 export * from "./update-inventory-modal-element.ts";
+export * from "./edit-device-definition-modal-element.ts";
 export * from "./click-to-copy-element";

--- a/web/src/services/identity-service.ts
+++ b/web/src/services/identity-service.ts
@@ -100,6 +100,18 @@ export interface DeviceDefinitionDetail {
   attributes?: DeviceDefinitionAttribute[];
 }
 
+export interface LatestDeviceDefinitionCloudEvent {
+  header?: {
+    id?: string;
+    type?: string;
+    time?: string;
+    source?: string;
+    producer?: string;
+    dataschema?: string;
+  };
+  data?: DeviceDefinitionDetail;
+}
+
 /**
  * Service for handling identity and account-related operations
  */
@@ -547,6 +559,52 @@ export class IdentityService {
       return response.data.deviceDefinition;
     } catch (error) {
       console.error('Error fetching device definition by ID:', error);
+      return null;
+    }
+  }
+
+  async getLatestDeviceDefinitionCloudEvent(tokenDID: string): Promise<LatestDeviceDefinitionCloudEvent | null> {
+    try {
+      const trimmedTokenDID = tokenDID.trim();
+      if (!trimmedTokenDID) {
+        return null;
+      }
+
+      const query = `query GetLatestDeviceDefinitionCloudEvent {
+        latestCloudEvent(
+          did: ${JSON.stringify(trimmedTokenDID)}
+          filter: { type: "dimo.document.devicedefinition" }
+        ) {
+          header {
+            id
+            type
+            time
+            source
+            producer
+            dataschema
+          }
+          data
+        }
+      }`;
+
+      const response = await this.apiService.callApi<{
+        latestCloudEvent?: LatestDeviceDefinitionCloudEvent | null;
+      }>(
+        'POST',
+        `/fleet/vehicles/fetch?did=${encodeURIComponent(trimmedTokenDID)}`,
+        query,
+        true,
+        true,
+        true
+      );
+
+      if (!response.success) {
+        return null;
+      }
+
+      return response.data?.latestCloudEvent ?? null;
+    } catch (error) {
+      console.error('Error fetching latest device definition CloudEvent:', error);
       return null;
     }
   }

--- a/web/src/services/identity-service.ts
+++ b/web/src/services/identity-service.ts
@@ -21,6 +21,7 @@ export interface AccountInfo {
 export interface VehicleIdentityData {
   vehicle?: {
     id?: string;
+    tokenDID?: string;
     owner?: string;
     sacds?: {
       nodes?: Array<{
@@ -88,6 +89,17 @@ export interface DeviceDefinitionsResult {
   pageInfo?: DeviceDefinitionsPageInfo;
 }
 
+export interface DeviceDefinitionDetail {
+  model?: string;
+  year?: number;
+  manufacturer?: {
+    name?: string;
+  };
+  deviceDefinitionId?: string;
+  deviceType?: string;
+  attributes?: DeviceDefinitionAttribute[];
+}
+
 /**
  * Service for handling identity and account-related operations
  */
@@ -123,6 +135,7 @@ export class IdentityService {
       const query = `{
         vehicle(tokenId: ${normalizedTokenId}) {
           id
+          tokenDID
           owner
           sacds(first: 15) {
             nodes {
@@ -489,6 +502,51 @@ export class IdentityService {
       };
     } catch (error) {
       console.error('Error fetching device definitions:', error);
+      return null;
+    }
+  }
+
+  async getDeviceDefinitionById(deviceDefinitionId: string): Promise<DeviceDefinitionDetail | null> {
+    try {
+      const trimmedId = deviceDefinitionId.trim();
+      if (!trimmedId) {
+        return null;
+      }
+
+      const query = `{
+        deviceDefinition(by: { id: ${JSON.stringify(trimmedId)} }) {
+          model
+          year
+          manufacturer {
+            name
+          }
+          deviceDefinitionId
+          deviceType
+          attributes {
+            name
+            value
+          }
+        }
+      }`;
+
+      const response = await this.apiService.callApi<{
+        deviceDefinition?: DeviceDefinitionDetail;
+      }>(
+        'POST',
+        '/identity/proxy',
+        { query },
+        false,
+        false,
+        false
+      );
+
+      if (!response.success || !response.data?.deviceDefinition) {
+        return null;
+      }
+
+      return response.data.deviceDefinition;
+    } catch (error) {
+      console.error('Error fetching device definition by ID:', error);
       return null;
     }
   }

--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -13,6 +13,7 @@ import '../elements/update-inventory-modal-element';
 import '../elements/fleet-map';
 import '../elements/click-to-copy-element';
 import '../elements/share-vehicle-modal-element';
+import '../elements/edit-device-definition-modal-element';
 
 dayjs.extend(relativeTime);
 
@@ -199,6 +200,9 @@ export class VehicleDetailView extends LitElement {
 
   @state()
   private showShareModal: boolean = false;
+
+  @state()
+  private showEditDefinitionModal: boolean = false;
 
   @state()
   private editingPlate: boolean = false;
@@ -537,6 +541,9 @@ export class VehicleDetailView extends LitElement {
                     @click=${() => { this.editPlateValue = this.vehicle?.license_plate || ''; this.editingPlate = true; }}>
                     ${this.vehicle?.license_plate || msg('+ Plate')}
                   </span>
+                  <button class="btn btn-sm" style="margin-left:12px;vertical-align:middle;" @click=${this.openEditDefinitionModal}>
+                    ${msg('UPDATE')}
+                  </button>
                 `}</h2>
                 <div style="margin-bottom: 8px;">
                   <span style="color: #666;">${msg('VIN:')}</span> ${this.vehicle?.vin}
@@ -937,6 +944,13 @@ export class VehicleDetailView extends LitElement {
         @modal-closed=${() => { this.showShareModal = false; }}
       ></share-vehicle-modal-element>
 
+      <edit-device-definition-modal-element
+        .show=${this.showEditDefinitionModal}
+        .deviceDefinitionId=${this.vehicle?.device_definition_id || this.vehicleIdentity?.vehicle?.definition?.id || ''}
+        .tokenDID=${this.vehicleIdentity?.vehicle?.tokenDID || ''}
+        @modal-closed=${this.handleEditDefinitionModalClosed}
+      ></edit-device-definition-modal-element>
+
       <!-- Update Inventory Modal -->
       <update-inventory-modal-element
         .show=${this.showInventoryModal}
@@ -964,6 +978,14 @@ export class VehicleDetailView extends LitElement {
 
   private handleInventoryModalClosed() {
     this.showInventoryModal = false;
+  }
+
+  private openEditDefinitionModal() {
+    this.showEditDefinitionModal = true;
+  }
+
+  private handleEditDefinitionModalClosed() {
+    this.showEditDefinitionModal = false;
   }
 
   private async handleInventoryUpdated(event: CustomEvent) {

--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -5,7 +5,11 @@ import {globalStyles} from "../global-styles.ts";
 import {consume} from '@lit/context';
 import {apiServiceContext} from '../context';
 import {ApiService} from '@services/api-service.ts';
-import {IdentityService, VehicleIdentityData} from '@services/identity-service.ts';
+import {
+  DeviceDefinitionDetail,
+  IdentityService,
+  VehicleIdentityData,
+} from '@services/identity-service.ts';
 import {OracleTenantService} from '@services/oracle-tenant-service.ts';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -38,6 +42,9 @@ interface TelemetryInfo {
     };
     powertrainFuelSystemRelativeLevel: {
       value: number;
+    };
+    powertrainFuelSystemAbsoluteLevel?: {
+      value: number | null;
     };
     powertrainTransmissionTravelledDistance: {
       value: number;
@@ -140,6 +147,8 @@ interface Vehicle {
 
 @customElement('vehicle-detail-view')
 export class VehicleDetailView extends LitElement {
+  private static readonly LITERS_PER_GALLON = 3.78541;
+
   static styles = [globalStyles, css`
     .license-plate {
       display: inline-block;
@@ -170,6 +179,9 @@ export class VehicleDetailView extends LitElement {
 
   @state()
   private vehicleIdentity: VehicleIdentityData | null = null;
+
+  @state()
+  private fuelTankCapacity: number | null = null;
 
   @state()
   private trips: Trip[] = [];
@@ -259,6 +271,9 @@ export class VehicleDetailView extends LitElement {
     powertrainFuelSystemRelativeLevel {
       value
     }
+    powertrainFuelSystemAbsoluteLevel {
+      value
+    }
     powertrainTransmissionTravelledDistance {
       value
       timestamp
@@ -317,6 +332,7 @@ export class VehicleDetailView extends LitElement {
     this.errorMessage = '';
     this.vehicle = null;
     this.vehicleIdentity = null;
+    this.fuelTankCapacity = null;
     this.lastTelemetry = null;
     this.trips = [];
     this.ownerInfo = null;
@@ -343,6 +359,7 @@ export class VehicleDetailView extends LitElement {
     this.vehicle = vehicle;
     this.vehicleIdentity = vehicleIdentity;
     this.lastTelemetry = telemetry;
+    this.fuelTankCapacity = await this.loadFuelTankCapacity(vehicle, vehicleIdentity);
 
     const errors = [vehicleError, telemetryError, identityError].filter((err): err is string => !!err);
     this.errorMessage = errors.length > 0 ? errors.join(' | ') : '';
@@ -413,6 +430,83 @@ export class VehicleDetailView extends LitElement {
       console.error('Error loading vehicle identity:', error);
       return [null, error.message || 'Error loading vehicle identity'];
     }
+  }
+
+  private async loadFuelTankCapacity(
+    vehicle: Vehicle,
+    vehicleIdentity: VehicleIdentityData | null
+  ): Promise<number | null> {
+    try {
+      const identityService = IdentityService.getInstance();
+      const tokenDID = vehicleIdentity?.vehicle?.tokenDID?.trim() || '';
+      const deviceDefinitionId =
+        vehicle.device_definition_id?.trim() || vehicleIdentity?.vehicle?.definition?.id?.trim() || '';
+
+      const [latestCloudEvent, identityDefinition] = await Promise.all([
+        tokenDID ? identityService.getLatestDeviceDefinitionCloudEvent(tokenDID) : Promise.resolve(null),
+        deviceDefinitionId ? identityService.getDeviceDefinitionById(deviceDefinitionId) : Promise.resolve(null),
+      ]);
+
+      return (
+        this.getFuelTankCapacityFromDefinition(latestCloudEvent?.data) ??
+        this.getFuelTankCapacityFromDefinition(identityDefinition)
+      );
+    } catch (error) {
+      console.error('Error loading fuel tank capacity:', error);
+      return null;
+    }
+  }
+
+  private getFuelTankCapacityFromDefinition(definition: DeviceDefinitionDetail | null | undefined): number | null {
+    const fuelTankCapacityAttribute = definition?.attributes?.find((attribute) =>
+      this.isFuelTankCapacityAttribute(attribute.name)
+    );
+
+    return this.parseFuelTankCapacity(fuelTankCapacityAttribute?.value);
+  }
+
+  private isFuelTankCapacityAttribute(attributeName?: string): boolean {
+    const normalizedName = (attributeName || '').replace(/[_-\s]/g, '').toLowerCase();
+    return normalizedName === 'fueltankcapacitygal';
+  }
+
+  private parseFuelTankCapacity(value?: string | null): number | null {
+    if (value == null) {
+      return null;
+    }
+
+    const parsedValue = Number(value);
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+      return null;
+    }
+
+    return parsedValue;
+  }
+
+  private getFuelLevelDisplay(): string {
+    const relativeFuelLevel = this.lastTelemetry?.signalsLatest.powertrainFuelSystemRelativeLevel?.value;
+    if (relativeFuelLevel != null && Number.isFinite(relativeFuelLevel)) {
+      return `${Math.round(relativeFuelLevel)}%`;
+    }
+
+    const absoluteFuelLevel = this.lastTelemetry?.signalsLatest.powertrainFuelSystemAbsoluteLevel?.value;
+    if (absoluteFuelLevel == null || !Number.isFinite(absoluteFuelLevel) || absoluteFuelLevel < 0) {
+      return 'N/A';
+    }
+
+    if (this.fuelTankCapacity == null || this.fuelTankCapacity <= 0) {
+      return 'N/A';
+    }
+
+    const fuelTankCapacityLiters = this.fuelTankCapacity * VehicleDetailView.LITERS_PER_GALLON;
+    if (!Number.isFinite(fuelTankCapacityLiters) || fuelTankCapacityLiters <= 0) {
+      return 'N/A';
+    }
+
+    const fuelLevelPercentage = (absoluteFuelLevel / fuelTankCapacityLiters) * 100;
+    const clampedFuelLevelPercentage = Math.min(100, Math.max(0, fuelLevelPercentage));
+
+    return `${Math.round(clampedFuelLevelPercentage)}%`;
   }
 
   private getWeekIntervals(): { label: string; from: string; to: string }[] {
@@ -759,7 +853,7 @@ export class VehicleDetailView extends LitElement {
                 </div>
                 <div class="detail-row">
                   <span class="detail-label">${msg('Fuel Level')}</span>
-                  <span class="detail-value">${this.lastTelemetry?.signalsLatest.powertrainFuelSystemRelativeLevel != null ? `${Math.round(this.lastTelemetry.signalsLatest.powertrainFuelSystemRelativeLevel.value)}%` : 'N/A'}</span>
+                  <span class="detail-value">${this.getFuelLevelDisplay()}</span>
                 </div>
                 <div class="detail-row">
                   <span class="detail-label">${msg('Odometer')}</span>
@@ -949,6 +1043,7 @@ export class VehicleDetailView extends LitElement {
         .deviceDefinitionId=${this.vehicle?.device_definition_id || this.vehicleIdentity?.vehicle?.definition?.id || ''}
         .tokenDID=${this.vehicleIdentity?.vehicle?.tokenDID || ''}
         @modal-closed=${this.handleEditDefinitionModalClosed}
+        @device-definition-update-requested=${this.handleDeviceDefinitionUpdated}
       ></edit-device-definition-modal-element>
 
       <!-- Update Inventory Modal -->
@@ -986,6 +1081,14 @@ export class VehicleDetailView extends LitElement {
 
   private handleEditDefinitionModalClosed() {
     this.showEditDefinitionModal = false;
+  }
+
+  private async handleDeviceDefinitionUpdated(_event: CustomEvent) {
+    this.showEditDefinitionModal = false;
+    this.successMessage = msg('Device definition update submitted.');
+
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    await this.loadVehicleData();
   }
 
   private async handleInventoryUpdated(event: CustomEvent) {


### PR DESCRIPTION
### What's Added:

 - Updates b2b Device Definition edit flow to proxy submissions to Kaufmann-Oracle instead of owning attestation logic locally.

 - Sends tokenDID plus the parsed device-definition document through the existing oracle proxy route.

 - Preserves and exposes editable device-definition attributes so Kaufmann-Oracle can build/sign/submit the CloudEvent.