### PR TITLE
feat: type signer_address on TenantSettings

### DIFF
--- a/web/src/services/settings-service.ts
+++ b/web/src/services/settings-service.ts
@@ -41,6 +41,7 @@ export interface TenantSettings {
     command_password: string;
     dimo_client_id: string;
     has_dimo_secret: boolean;
+    signer_address?: string;
 }
 
 const PRIVATE_SETTINGS_KEY = "appPrivateSettings";


### PR DESCRIPTION
## Summary
- Adds optional `signer_address` field to the `TenantSettings` TypeScript interface to match the new field returned by `GET /tenant/settings` in kaufmann-oracle.
- No UI changes yet — purely typing so views can read the field once the backend rolls out.

Pairs with: DIMO-Network/kaufmann-oracle#92

## Test plan
- [ ] After kaufmann-oracle#92 deploys + `backfill-tenant-signers` runs, confirm `settings.tenantSettings?.signer_address` is populated when fetching tenant settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)