### PR TITLE
feat: allow transfer for shared-account vehicles

### DIFF
--- a/.github/workflows/helmlint.yml
+++ b/.github/workflows/helmlint.yml
@@ -1,0 +1,19 @@
+name: Helm Lint and Test Charts
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helmlint.yml'
+
+jobs:
+  helm-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: helm-check
+        uses: igabaydulin/helm-check-action@0.2.1
+        env:
+          CHART_LOCATION: ./charts/fleet-onboard-app
+          CHART_VALUES: ./charts/fleet-onboard-app/values.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,16 +10,18 @@ jobs:
     name: lint
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
-          cache: false
+          go-version: 1.25.x
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           only-new-issues: false
           working-directory: api
-          install-mode: "goinstall"
           args: --modules-download-mode=readonly --timeout=10m

--- a/.github/workflows/weblint.yml
+++ b/.github/workflows/weblint.yml
@@ -1,0 +1,32 @@
+name: web-lint
+on:
+  pull_request:
+    branches: [ '**' ]
+    paths:
+      - 'web/**'
+      - '.github/workflows/weblint.yml'
+
+jobs:
+  eslint:
+    name: eslint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install deps
+        run: npm ci
+
+      # Lenient: warnings are fine, only ESLint errors fail the build.
+      # The cap exists so that a runaway regression (e.g. doubling current count) still trips CI.
+      - name: ESLint
+        run: npx eslint src --max-warnings 500

--- a/web/src/elements/base-onboarding-element.ts
+++ b/web/src/elements/base-onboarding-element.ts
@@ -386,6 +386,49 @@ export class BaseOnboardingElement extends LitElement {
         };
     }
 
+    // transferSharedAccountVehicle is the server-signed transfer flow used when the vehicle's
+    // on-chain owner is a shared kernel account that registered our tenant's signer. The
+    // backend (POST /v1/vehicle/transfer/shared) validates and submits the on-chain
+    // safeTransferFrom itself, so no passkey signature is required from the connected wallet.
+    async transferSharedAccountVehicle(tokenId: number, targetWallet: string): Promise<Result<void, string>> {
+        this.dispatchStatusUpdate(msg("Submitting shared-account transfer..."));
+        const submitResp = await this.api.callApi<VinTransferResponse>(
+            'POST',
+            '/vehicle/transfer/shared',
+            { tokenId, targetWalletAddress: targetWallet },
+            true,
+        );
+        if (!submitResp.success || !submitResp.data) {
+            return { success: false, error: submitResp.error || "Failed to submit shared-account transfer" };
+        }
+
+        // Same status-poll pattern as submitTransferData — backend marks the river job
+        // 'Success' once the safeTransferFrom UserOp lands on chain.
+        let success = false;
+        for (const attempt of range(30)) {
+            const query = qs.stringify({ jobId: submitResp.data.jobId });
+            const status = await this.api.callApi<VinStatus>('GET', `/vehicle/transfer/status?${query}`, null, true);
+            this.dispatchStatusUpdate(msg("Checking transfer status... ") + attempt);
+            if (!status.success || !status.data) {
+                return { success: false, error: status.error || "Failed to check transfer status" };
+            }
+            if (status.data.status === 'Success') {
+                success = true;
+                break;
+            }
+            if (attempt < 29) {
+                await delay(4000);
+            }
+        }
+
+        if (!success) {
+            return { success: false, error: "Transfer operation timed out" };
+        }
+
+        this.dispatchStatusUpdate(msg("Transfer completed successfully"));
+        return { success: true, data: undefined };
+    }
+
     // transferVehicle coordinates all of the necessary calls to get the data to sign, signing it and submitting the trx to transfer a vehicle
     async transferVehicle(imei: string, targetWallet: string) : Promise<Result<void, string>> {
         this.dispatchStatusUpdate(msg("Fetching transfer data..."));

--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -62,6 +62,15 @@ export class TransferModalElement extends BaseOnboardingElement {
     @property({attribute: true})
     public imei = "";
 
+    @property({attribute: true, type: Number})
+    public tokenId = 0;
+
+    // When true, the connected wallet isn't the on-chain owner but the owning kernel
+    // authorised this tenant's signer — so the backend signs the transfer for us via
+    // POST /v1/vehicle/transfer/shared instead of asking the wallet for a passkey signature.
+    @property({attribute: true, type: Boolean})
+    public useSharedAccountFlow = false;
+
     @state()
     private walletAddress = "";
 
@@ -282,8 +291,11 @@ export class TransferModalElement extends BaseOnboardingElement {
         }
 
         console.log("Target Wallet to transfer to", this.walletAddress);
-        // this method does a lot of steps. It also checks the status of the transfer, which should be separated out into own function.
-        const result = await this.transferVehicle(this.imei, this.walletAddress);
+        // Shared-account vehicles can't be passkey-signed by the connected wallet (it isn't
+        // the owner). The backend signs server-side via the tenant signer.
+        const result = this.useSharedAccountFlow
+            ? await this.transferSharedAccountVehicle(this.tokenId, this.walletAddress)
+            : await this.transferVehicle(this.imei, this.walletAddress);
         if (!result.success) {
             if (result.error.toLowerCase().includes('timeout')) {
                 this.errorMessage = msg("Check Info for final transfer verification");

--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -51,6 +51,36 @@ export class TransferModalElement extends BaseOnboardingElement {
             gap: 8px;
             margin-top: 8px;
           }
+          .shared-account-banner {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            background-color: #eff6ff;
+            border: 1px solid #bfdbfe;
+            border-left: 4px solid #2563eb;
+            border-radius: 4px;
+            padding: 10px 12px;
+            margin-bottom: 16px;
+            color: #1e3a8a;
+            font-size: 13px;
+            line-height: 1.4;
+          }
+          .shared-account-badge {
+            display: inline-block;
+            flex: 0 0 auto;
+            background-color: #2563eb;
+            color: #fff;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            padding: 2px 8px;
+            border-radius: 999px;
+            white-space: nowrap;
+          }
+          .shared-account-text {
+            flex: 1 1 auto;
+          }
         `
     ];
     @property({attribute: true, type: Boolean})
@@ -127,6 +157,14 @@ export class TransferModalElement extends BaseOnboardingElement {
                         <button type="button" class="modal-close" @click=${this.closeModal}>×</button>
                     </div>
                         <div class="modal-body">
+                            ${this.useSharedAccountFlow ? html`
+                                <div class="shared-account-banner" role="status" aria-label=${msg('Shared account mode')}>
+                                    <span class="shared-account-badge">${msg('Shared account mode')}</span>
+                                    <span class="shared-account-text">
+                                        ${msg('This vehicle is owned by a kernel account that authorised your tenant signer. Your tenant will sign and submit the transfer on its behalf — no passkey signature is required.')}
+                                    </span>
+                                </div>
+                            ` : nothing}
                             ${this.errorMessage ? html`
                                 <div style="background-color: #fee; border: 1px solid #fcc; border-radius: 4px; padding: 12px; margin-bottom: 16px; color: #c33;">
                                     ${this.errorMessage}

--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -115,7 +115,7 @@ export class VehicleListItemElement extends BaseOnboardingElement {
                   </button>
                   <button
                       type="button"
-                      ?hidden=${this.item.tokenId == 0 || !this.item.isCurrentUserOwner}
+                      ?hidden=${this.item.tokenId == 0 || (!this.item.isCurrentUserOwner && !this.item.isSharedAccountSigner)}
                       ?disabled=${this.processing}
                       @click=${this.openTransferModal}
                       class="action-btn"
@@ -327,6 +327,10 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         modal.show = true;
         modal.vehicleVin = this.item?.vin || '';
         modal.imei = this.item?.imei || '';
+        modal.tokenId = this.item?.tokenId || 0;
+        // The connected wallet isn't the literal owner but our tenant can sign for the
+        // owning kernel — modal will use the server-signed shared-account flow.
+        modal.useSharedAccountFlow = !!(this.item && !this.item.isCurrentUserOwner && this.item.isSharedAccountSigner);
 
         // Add event listener for modal close
         modal.addEventListener('modal-closed', () => {

--- a/web/src/types/vehicle.ts
+++ b/web/src/types/vehicle.ts
@@ -23,4 +23,8 @@ export interface Vehicle {
     connectionStatus: string;       // status of connection to the vendor
     disconnectionStatus: string;    // status of disconnection from vendor
     isCurrentUserOwner: boolean;
+    // True when the on-chain owner is a shared kernel account that authorised the current
+    // tenant's signer (via providedSignerAddress at account creation). Lets the tenant drive
+    // transfers on its behalf even though isCurrentUserOwner is false.
+    isSharedAccountSigner?: boolean;
 }


### PR DESCRIPTION
## Summary
Keeps the **Transfer** button enabled (and wires the action through end-to-end) for vehicles whose on-chain owner is a shared kernel account that authorised the current tenant's signer at account creation. The kaufmann-oracle backend ([DIMO-Network/kaufmann-oracle#100](https://github.com/DIMO-Network/kaufmann-oracle/pull/100)) now surfaces an `isSharedAccountSigner` flag on each vehicle in `GET /v1/vehicles`; this PR consumes it.

## Changes
- **`types/vehicle.ts`** — added optional `isSharedAccountSigner?: boolean` to the `Vehicle` interface.
- **`vehicle-list-item-element.ts`**
  - Transfer button is hidden only when `tokenId == 0 || (!isCurrentUserOwner && !isSharedAccountSigner)`.
  - When opening the transfer modal, plumbs `tokenId` and a derived `useSharedAccountFlow` (true when shared and not the literal owner).
- **`transfer-modal-element.ts`**
  - New `tokenId` and `useSharedAccountFlow` properties.
  - `confirmTransfer` branches to the new server-signed flow when `useSharedAccountFlow` is true. Existing passkey flow is untouched for the normal owner case.
- **`base-onboarding-element.ts`** — new `transferSharedAccountVehicle(tokenId, targetWallet)`. Posts `{ tokenId, targetWalletAddress }` to `/vehicle/transfer/shared`, then polls `/vehicle/transfer/status?jobId=…` with the same 30 × 4 s loop the existing flow uses.

## Notes
- Other ownership-keyed UI (disconnect button, delete button, the "TRANSFERRED" status pill) intentionally still keys on `isCurrentUserOwner` — this PR scopes to the transfer button per request. Happy to widen in a follow-up if shared-account vehicles should also support those operations from the same view.

## Test plan
- [ ] Sign in as a tenant whose signer was registered as `providedSignerAddress` for a shared kernel account that owns a vehicle; confirm the row's transfer button is visible and that clicking it submits to `POST /vehicle/transfer/shared` and polls to success.
- [ ] Verify the regular passkey transfer flow (vehicles you literally own) still works unchanged.
- [ ] Verify a vehicle owned by a wallet you don't own and didn't authorise still hides the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
