### PR TITLE
fix(web): add dayjs as direct dep; build in lint CI

### DIFF
--- a/.github/workflows/weblint.yml
+++ b/.github/workflows/weblint.yml
@@ -30,3 +30,8 @@ jobs:
       # The cap exists so that a runaway regression (e.g. doubling current count) still trips CI.
       - name: ESLint
         run: npx eslint src --max-warnings 500
+
+      # tsc + vite build catches things ESLint can't, like missing modules and type errors —
+      # the kind of regression that otherwise only shows up in the docker buildpushdev step.
+      - name: Build
+        run: npm run build

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "@turnkey/webauthn-stamper": "^0.6.0",
         "@zerodev/ecdsa-validator": "^5.4.9",
         "@zerodev/sdk": "^5.5.6",
+        "dayjs": "^1.11.20",
         "events": "^3.3.0",
         "leaflet": "^1.9.4",
         "lit": "^3.2.1",
@@ -5100,6 +5101,12 @@
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "@turnkey/webauthn-stamper": "^0.6.0",
     "@zerodev/ecdsa-validator": "^5.4.9",
     "@zerodev/sdk": "^5.5.6",
+    "dayjs": "^1.11.20",
     "events": "^3.3.0",
     "leaflet": "^1.9.4",
     "lit": "^3.2.1",


### PR DESCRIPTION
## Summary
Restores the broken main build. PR #111 (`Bump fast-xml-parser and @dimo-network/transactions`) bumped `@dimo-network/transactions` from `0.1.x` to `0.3.x`, which dropped `dayjs` from the transitive dep tree. The app uses `dayjs` directly in 5+ files (`share-vehicle-modal-element.ts`, `vehicle-sharing-panel-element.ts`, `tracking/tracking-app.ts`, `views/reports.ts`, `views/vehicle-detail.ts`, `views/vehicles-fleets.ts`) but never declared it as a direct dep — it had been working only because the older `@dimo-network/transactions` pulled it in.

The first `buildpushdev` after PR #114 merged failed with `TS2307: Cannot find module 'dayjs'`. ESLint missed it because it doesn't do type resolution.

## Changes
- Added `dayjs` as a direct dependency in `web/package.json` (`^1.11.20`) and updated `package-lock.json`.
- Strengthened the `web-lint` workflow to also run `npm run build` (`tsc` + `vite build`). Catches missing modules and type errors so we don't have to wait for the docker buildpushdev step to surface them.

## Test plan
- [x] `npm run build` passes locally.
- [ ] Confirm `web-lint` and `buildpushdev` go green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
