### PR TITLE
fix(web): transfer modal tenant header + input width; inline Shared badge

### DIFF
--- a/web/src/elements/all-users-table-element.ts
+++ b/web/src/elements/all-users-table-element.ts
@@ -147,7 +147,6 @@ export class AllUsersTable extends LitElement {
                   <table>
                     <thead>
                       <tr>
-                        <th>${msg('Type')}</th>
                         <th>${msg('Wallet')}</th>
                         <th>${msg('Email')}</th>
                         <th>${msg('First Name')}</th>
@@ -160,16 +159,16 @@ export class AllUsersTable extends LitElement {
                       ${this.users.map(
                         (user) => html`
                           <tr>
-                            <td>
-                              ${user.shared_account_signer_address
-                                ? html`<span
-                                    class="shared-badge"
-                                    title=${msg('Shared account — your tenant signer is authorised to act on this kernel\'s behalf')}
-                                  >${msg('Shared')}</span>`
-                                : ""}
-                            </td>
                             <td style="font-family: monospace; font-size: 13px;">
-                              ${user.wallet || "-"}
+                              <span style="display: inline-flex; align-items: center; gap: 8px;">
+                                <span>${user.wallet || "-"}</span>
+                                ${user.shared_account_signer_address
+                                  ? html`<span
+                                      class="shared-badge"
+                                      title=${msg('we have control over any vehicle under this account to transfer or delete')}
+                                    >${msg('Shared')}</span>`
+                                  : ""}
+                              </span>
                             </td>
                             <td>
                               ${user.email

--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -183,13 +183,14 @@ export class TransferModalElement extends BaseOnboardingElement {
                                         <label>
                                             ${msg('Wallet 0x Address (for existing accounts)')}
                                             <div style="display: flex; align-items: center; gap: 8px;">
-                                                <input type="text" 
-                                                       placeholder="0x..." 
+                                                <input type="text"
+                                                       placeholder="0x..."
                                                        maxlength="42"
+                                                       style="flex: 1; min-width: 0;"
                                                        .value=${this.walletAddress}
                                                        @input=${this.handleWalletInput}>
-                                                ${this.isCheckingAccount ? html`<span style="font-size: 12px; color: #666;">${msg('Checking...')}</span>` : nothing}
-                                                ${this.accountFound ? html`<span style="color: #22c55e; font-size: 16px;">✓</span>` : nothing}
+                                                ${this.isCheckingAccount ? html`<span style="font-size: 12px; color: #666; flex: 0 0 auto;">${msg('Checking...')}</span>` : nothing}
+                                                ${this.accountFound ? html`<span style="color: #22c55e; font-size: 16px; flex: 0 0 auto;">✓</span>` : nothing}
                                             </div>
                                         </label>
                                         ${this.walletAddress && this.accountNotFound ? html`
@@ -287,7 +288,8 @@ export class TransferModalElement extends BaseOnboardingElement {
     private async lookupAccount(walletAddress: string) {
         this.isCheckingAccount = true;
         const query = `?walletAddress=${encodeURIComponent(walletAddress)}`;
-        const resp = await this.api.callApi<any>('GET', `/account${query}`, null, true, true, false);
+        // Backend GET /account requires Tenant-Id (matches the POST /account create path).
+        const resp = await this.api.callApi<any>('GET', `/account${query}`, null, true, true, true);
         // If request failed or no body, show helper text
         if (!resp.success || !resp.data) {
             this.accountNotFound = true;


### PR DESCRIPTION
## Summary
Three small frontend polish fixes.

## Changes

### Transfer modal
- **Send `Tenant-Id` header on the wallet lookup.** `lookupAccount` was calling `GET /account` with `includeTenantId=false`, which made the kaufmann backend return `400 tenant id is missing`. The companion `POST /account` create call already passes `includeTenantId=true`; the GET now matches.
- **Wallet 0x input fills the row width.** Added `flex: 1; min-width: 0;` to the input and `flex: 0 0 auto;` to the inline indicator spans. The input now stretches to fill the form like the email input, and the "Checking..." / ✓ indicators sit on the right without squashing it.

### All Users view
- **Drop the standalone `Type` column** and inline the **Shared** pill next to the wallet address instead. Avoids a mostly-empty column and keeps the badge close to the identity it qualifies.
- Tooltip updated to: *"we have control over any vehicle under this account to transfer or delete"*.

## Test plan
- [ ] Transfer modal: type a valid 0x wallet — confirm lookup returns 200 (no more 400) and ✓ shows.
- [ ] Wallet input visually matches email input width.
- [ ] All Users view: shared accounts show the blue pill inline with the wallet; no `Type` column header; tooltip on hover reads as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
