### PR TITLE
fix(api): proxy POST /vehicle/transfer/shared to the oracle

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -147,6 +147,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	// Transfer vehicle
 	oracleApp.Get("/vehicle/transfer", vehiclesCtrl.GetTransferData)
 	oracleApp.Post("/vehicle/transfer", vehiclesCtrl.SubmitTransferData)
+	oracleApp.Post("/vehicle/transfer/shared", vehiclesCtrl.SubmitSharedAccountTransfer)
 	oracleApp.Get("/vehicle/transfer/status", vehiclesCtrl.GetTransferStatus)
 
 	// Delete vehicle

--- a/api/internal/controllers/vehicles.go
+++ b/api/internal/controllers/vehicles.go
@@ -202,6 +202,16 @@ func (v *VehiclesController) GetTransferStatus(c *fiber.Ctx) error {
 	return ProxyRequest(c, targetURL, nil, v.logger)
 }
 
+// SubmitSharedAccountTransfer forwards the server-signed transfer request to the kaufmann
+// oracle endpoint that signs on behalf of a shared kernel account using the tenant signer.
+// Body: { tokenId, targetWalletAddress }. Response: { jobId }.
+func (v *VehiclesController) SubmitSharedAccountTransfer(c *fiber.Ctx) error {
+	u := GetOracleURL(c, v.settings)
+
+	targetURL := u.JoinPath("/v1/vehicle/transfer/shared")
+	return ProxyRequest(c, targetURL, c.Body(), v.logger)
+}
+
 func (v *VehiclesController) SubmitCommand(c *fiber.Ctx) error {
 	imei := c.Params("imei", "")
 


### PR DESCRIPTION
## Summary
Adds the missing proxy route for `POST /vehicle/transfer/shared`. The frontend was getting a 404 when trying to submit a shared-account transfer because the b2b api proxy never forwarded the request to the kaufmann oracle.

## Changes
- New handler `VehiclesController.SubmitSharedAccountTransfer` — thin pass-through to `POST /v1/vehicle/transfer/shared` on the oracle (matches the existing `SubmitTransferData` shape).
- Registered the new route in `app.go` next to the existing transfer routes.

## Test plan
- [ ] After deploy, click Transfer on a shared-account vehicle from the b2b UI; confirm the request reaches the oracle and `{ jobId }` comes back (no more 404).
- [ ] Existing regular transfer flow still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
