### PR TITLE
Sync vins.owner from identity on vehicle-detail view

### DIFF
--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -145,6 +145,9 @@ interface Vehicle {
   inventory_audit: InventoryAudit[];
   vendor_data?: Record<string, string>;
   license_plate?: string;
+  // owner is the last known on-chain owner stored in kaufmann's vins table. Identity is the
+  // source of truth; we compare against it on detail load and PATCH back when it drifts.
+  owner?: string;
 }
 
 @customElement('vehicle-detail-view')
@@ -383,11 +386,36 @@ export class VehicleDetailView extends LitElement {
     const errors = [vehicleError, telemetryError, identityError].filter((err): err is string => !!err);
     this.errorMessage = errors.length > 0 ? errors.join(' | ') : '';
 
+    // Fire-and-forget: if identity's owner has drifted from what kaufmann has cached in vins,
+    // PATCH it back. Skipped silently when they already match — no extra writes on the common
+    // path. Not awaited so it never delays the render.
+    void this.maybeSyncOwner(this.tokenID, vehicle.owner, vehicleIdentity?.vehicle?.owner);
+
     // Continue loading auxiliary sections even if telemetry/identity are unavailable.
     await this.loadTrips(this.tokenID);
     await this.loadOwnerInfo(this.tokenID);
 
     return [this.vehicle, this.errorMessage || null];
+  }
+
+  private async maybeSyncOwner(tokenId: number, localOwner: string | undefined, identityOwner: string | undefined): Promise<void> {
+    if (!this.apiService || !identityOwner) return;
+    if (localOwner && localOwner.toLowerCase() === identityOwner.toLowerCase()) return;
+
+    try {
+      const response = await this.apiService.callApi(
+        'PATCH',
+        `/fleet/vehicles/${tokenId}/owner`,
+        { owner: identityOwner },
+        true,
+        true
+      );
+      if (!response.success) {
+        console.warn('Owner sync to kaufmann failed:', response.error);
+      }
+    } catch (error) {
+      console.warn('Owner sync to kaufmann threw:', error);
+    }
   }
 
   private async loadVehicle(tokenId: number): Promise<[Vehicle | null, string | null]> {


### PR DESCRIPTION
## Summary
- The kaufmann `GET /fleet/vehicles/{tokenID}` response now includes `owner` (from the `vins` table) — see DIMO-Network/kaufmann-oracle#104 (v1.6.3).
- On vehicle-detail load, after both the kaufmann vehicle response and the Identity GraphQL call resolve, compare the two `owner` values (case-insensitive). If they drift, fire `PATCH /fleet/vehicles/{tokenID}/owner` so kaufmann updates `vins.owner` to match Identity.
- The PATCH is fire-and-forget — `void`'d, not `await`'d — so it never blocks the render. Failures are logged at `console.warn` and otherwise ignored; the next view load (or the batch `sync-owners` job) corrects anything that stays stale.
- When the values already match, no request is sent at all. So the common path costs zero extra requests.

Pairs with kaufmann-oracle v1.6.3 — requires that release in the env before this rolls out.

## Test plan
- [ ] `npx tsc --noEmit` passes locally (verified)
- [ ] `npm run build` passes locally (verified)
- [ ] Open the detail view for a vehicle whose `vins.owner` matches identity — confirm no `PATCH /fleet/vehicles/.../owner` request fires in the network tab
- [ ] Force a mismatch (e.g. manually clear `vins.owner` in DB) — open the detail view, confirm one `PATCH` fires with the identity owner, returns 204, and `vins.owner` is now populated
- [ ] Subsequent reload now matches → no PATCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)