### PR TITLE
Check isSuccessful on transfer status response, not the wrong field

### DIFF
--- a/web/src/elements/base-onboarding-element.ts
+++ b/web/src/elements/base-onboarding-element.ts
@@ -71,6 +71,16 @@ export interface VinsStatusResult {
     statuses: VinStatus[];
 }
 
+// TransferJobStatus is the response shape for GET /vehicle/transfer/status — a single river-job
+// status, not the array shape VinsStatusResult returns. Success is signalled by `isSuccessful`,
+// not by a "Success" string on a `status` field (the old shape this code used to assume).
+export interface TransferJobStatus {
+    attempt: number;
+    errors: string[];
+    isSuccessful: boolean;
+    state: string;
+}
+
 export class BaseOnboardingElement extends LitElement {
 
     @property({attribute: false})
@@ -346,11 +356,10 @@ export class BaseOnboardingElement extends LitElement {
         }
 
         // todo could probably refactor this pattern with two other functions
-        let success = true;
+        let success = false;
         for (const attempt of range(30)) {
-            success = true;
             const query = qs.stringify({jobId: mintResponse.data.jobId});
-            const status = await this.api.callApi<VinStatus>('GET', `/vehicle/transfer/status?${query}`, null, true);
+            const status = await this.api.callApi<TransferJobStatus>('GET', `/vehicle/transfer/status?${query}`, null, true);
             this.dispatchStatusUpdate("Checking transfer status... " + attempt);
 
             if (!status.success || !status.data) {
@@ -360,11 +369,8 @@ export class BaseOnboardingElement extends LitElement {
                 };
             }
 
-            if (status.data.status !== 'Success') {
-                success = false;
-            }
-
-            if (success) {
+            if (status.data.isSuccessful) {
+                success = true;
                 break;
             }
 
@@ -402,17 +408,17 @@ export class BaseOnboardingElement extends LitElement {
             return { success: false, error: submitResp.error || "Failed to submit shared-account transfer" };
         }
 
-        // Same status-poll pattern as submitTransferData — backend marks the river job
-        // 'Success' once the safeTransferFrom UserOp lands on chain.
+        // Same status-poll pattern as submitTransferData — backend flips isSuccessful=true on the
+        // job once the safeTransferFrom UserOp lands on chain.
         let success = false;
         for (const attempt of range(30)) {
             const query = qs.stringify({ jobId: submitResp.data.jobId });
-            const status = await this.api.callApi<VinStatus>('GET', `/vehicle/transfer/status?${query}`, null, true);
+            const status = await this.api.callApi<TransferJobStatus>('GET', `/vehicle/transfer/status?${query}`, null, true);
             this.dispatchStatusUpdate(msg("Checking transfer status... ") + attempt);
             if (!status.success || !status.data) {
                 return { success: false, error: status.error || "Failed to check transfer status" };
             }
-            if (status.data.status === 'Success') {
+            if (status.data.isSuccessful) {
                 success = true;
                 break;
             }


### PR DESCRIPTION
## Summary
The transfer modal kept polling `/vehicle/transfer/status` for the full 30 attempts even after the backend had already reported success. In production this surfaced as "Transfer operation timed out" on transfers that actually succeeded on-chain.

**Root cause:** both pollers (`submitTransferData` for the regular flow and `transferSharedAccountVehicle` for the shared-account flow) typed the response as `VinStatus` and checked `status.data.status === 'Success'`. But `VinStatus` is the shape used by the *plural* `/vehicle/disconnect/status` and `/vehicle/delete/status` endpoints (array entries inside `VinsStatusResult`). The *singular* `/vehicle/transfer/status` endpoint returns a different payload:

```json
{ "attempt": 1, "errors": [], "isSuccessful": true, "state": "completed" }
```

There's no `status` field at all, so the check could never succeed — the loop ran to its 30-attempt limit and then bailed out with a timeout error.

**Fix:** add a `TransferJobStatus` interface that actually matches the payload, retype both pollers to use it, and break on `isSuccessful`.

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [ ] Regular transfer: submit a transfer, confirm the modal closes successfully ~1 poll after the backend job completes (no spurious timeout, no continued polling after success)
- [ ] Shared-account transfer: same as above for the server-signed flow

## Follow-up not in this PR
Terminal failures still look like timeouts because the success path was the only signal. Could add an early-exit for `state === 'failed'` or non-empty `errors[]`, but that's a separate change and the user reported only the success path in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)