### PR TITLE
Sync vins.owner from identity when opening the onboarding info modal

### DIFF
--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -357,7 +357,7 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         document.body.appendChild(modal);
     }
 
-    private openIdentityInfoModal() {
+    private async openIdentityInfoModal() {
         console.log("Opening identity info modal for token ID:", this.item?.tokenId);
 
         // Create the identity info modal using the separate component
@@ -373,10 +373,34 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         // Add to body
         document.body.appendChild(modal);
 
-        // Load identity data after the modal is added to the DOM
-        setTimeout(() => {
-            modal.loadIdentityData();
-        }, 100);
+        // Load identity data, then mirror vehicle-detail.ts: if the on-chain owner returned by
+        // Identity has drifted from vins.owner (what `Vehicle.owner` carries on this row), fire
+        // PATCH /fleet/vehicles/{tokenID}/owner to self-heal. Identity is the source of truth.
+        try {
+            await modal.loadIdentityData();
+            void this.maybeSyncOwner(this.item?.tokenId, this.item?.owner, modal.identityData?.vehicle?.owner);
+        } catch (err) {
+            console.warn('Failed to load identity data for owner sync:', err);
+        }
+    }
+
+    private async maybeSyncOwner(tokenId: number | undefined, localOwner: string | undefined, identityOwner: string | undefined): Promise<void> {
+        if (!tokenId || !identityOwner) return;
+        if (localOwner && localOwner.toLowerCase() === identityOwner.toLowerCase()) return;
+
+        const resp = await this.api.callApi(
+            'PATCH',
+            `/fleet/vehicles/${tokenId}/owner`,
+            { owner: identityOwner },
+            true,
+            true
+        );
+        if (!resp.success) {
+            console.warn('Owner sync to kaufmann failed:', resp.error);
+            return;
+        }
+        // Refresh the list so the row reflects the corrected owner.
+        this.dispatchEvent(new CustomEvent('item-changed', { bubbles: true, composed: true }));
     }
 
     private openTelemetryModal() {


### PR DESCRIPTION
## Summary
Extends the self-heal pattern shipped in #118 (vehicle-detail view) to the onboarding list. When a user clicks the Info icon on a row, the identity-info modal fetches the on-chain owner from Identity (the source of truth). We now compare it against the row's `Vehicle.owner` — which kaufmann's `GET /v1/vehicles` list already populates from `vins.owner` — and fire `PATCH /fleet/vehicles/{tokenID}/owner` if they drift. No request fires when they already match.

## Changes
- `web/src/elements/vehicle-list-item-element.ts`:
  - `openIdentityInfoModal` is now `async` and `await`s `modal.loadIdentityData()` (replaces the prior fire-and-forget `setTimeout`). Once identity is loaded, calls a new `maybeSyncOwner` helper.
  - `maybeSyncOwner` does the case-insensitive compare and, on drift, PATCHes the kaufmann endpoint and dispatches `item-changed` so the list reloads with the corrected owner.

The b2b proxy route for `PATCH /fleet/vehicles/:tokenID/owner` was already wired up (see `api/internal/app/app.go`).

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [ ] On the onboarding view, click the Info icon for a row whose `vins.owner` matches identity — confirm no `PATCH /fleet/vehicles/{tokenID}/owner` fires in the network tab
- [ ] Force a mismatch (clear `vins.owner` in DB or sync-owners on a known-stale vin) — click Info on that row, confirm one PATCH fires with the identity owner, returns 204, and the list reloads with the owner now populated
- [ ] Reload the page after — Info icon no longer triggers a PATCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)