### PR TITLE
Consolidate delete-button eligibility into canDelete()

### DIFF
--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -106,8 +106,8 @@ export class VehicleListItemElement extends BaseOnboardingElement {
                   -->
                   <button
                       type="button"
-                      ?hidden=${this.item.tokenId == 0 || !this.item.isCurrentUserOwner}
-                      ?disabled=${this.item.syntheticDevice.tokenId || this.processing}
+                      ?hidden=${!this.canDelete(this.item)}
+                      ?disabled=${this.processing}
                       @click=${this.deleteVehicle}
                       class=${this.deletionProcessing ? 'processing action-btn secondary' : 'action-btn secondary'}
                   >
@@ -194,7 +194,13 @@ export class VehicleListItemElement extends BaseOnboardingElement {
     }
 
     canDelete(item: Vehicle): boolean {
-        return [ConnectionStatus.CONNECTED, ConnectionStatus.DISCONNECTION_FAILED].includes(this.getConnectionStatus(item));
+        if (item.tokenId === 0) return false;
+        if (!item.isCurrentUserOwner) return false;
+        return [
+            ConnectionStatus.UNKNOWN,
+            ConnectionStatus.DISCONNECTED,
+            ConnectionStatus.CONNECTION_FAILED,
+        ].includes(this.getConnectionStatus(item));
     }
 
     private dispatchItemChanged() {


### PR DESCRIPTION
## Summary
The delete button on the onboarding vehicle list had its hide/disable rules split across two template expressions, and the existing `canDelete()` helper was dead code returning the *inverse* of what the button actually checked.

This PR makes `canDelete()` the single source of truth (mirroring `canConnect()` / `canDisconnect()`) and points the button at it.

## Eligibility rules (now all in one place)
A row's delete button is shown when **all** are true:
- Vehicle has an on-chain token (`tokenId !== 0`)
- Current user owns it (`isCurrentUserOwner`)
- Connection status is one of: `UNKNOWN`, `DISCONNECTED`, `CONNECTION_FAILED` (same set as `canConnect()` — i.e. no active synthetic device)

## Behavioral change worth flagging
Previously, when a synthetic device was still attached, the button was *visible-but-disabled*. It is now *hidden* until the vehicle reaches a deletable state. This matches how `force delete` and `disconnect` already appear/disappear by state.

Also closes a small bug: in-flight `DISCONNECTING` / `CONNECTING` states used to leave the button enabled if the row's transient `processing` flag happened to be false (e.g. after a page reload mid-disconnect).

## Test plan
- [ ] Vehicle without an NFT (`tokenId == 0`) — delete button hidden.
- [ ] Vehicle transferred to another wallet — delete button hidden, `force delete` shown.
- [ ] Owned vehicle, currently connected — delete button hidden; `disconnect` shown instead.
- [ ] Owned vehicle, freshly disconnected (status = DISCONNECTED) — delete button appears and works.
- [ ] Owned vehicle that failed to connect (CONNECTION_FAILED) — delete button appears.
- [ ] Owned vehicle with no connection history (UNKNOWN) — delete button appears.
- [ ] Refresh page mid-disconnect (status = DISCONNECTING) — delete button stays hidden until disconnect completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)