### PR TITLE
Separate ownership from connection status on vehicle row

### DIFF
--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -15,7 +15,6 @@ enum ConnectionStatus {
     DISCONNECTING,
     DISCONNECTION_FAILED,
     DISCONNECTED,
-    TRANSFERRED
 }
 
 const connectionStatusLabel = (status: ConnectionStatus): string => {
@@ -27,7 +26,6 @@ const connectionStatusLabel = (status: ConnectionStatus): string => {
         case ConnectionStatus.DISCONNECTING: return msg("Disconnecting...");
         case ConnectionStatus.DISCONNECTION_FAILED: return msg("Disconnection failed");
         case ConnectionStatus.DISCONNECTED: return msg("Disconnected");
-        case ConnectionStatus.TRANSFERRED: return msg("Transferred");
     }
 };
 
@@ -66,6 +64,7 @@ export class VehicleListItemElement extends BaseOnboardingElement {
               <td>${this.item.tokenId}</td>
               <td>
                   <span class=${this.getConnectionCSSClass(this.item)}>${connectionStatusLabel(this.getConnectionStatus(this.item))}</span>
+                  ${this.isExternallyOwned(this.item) ? html`<span class="status status-not-owned" title=${msg('On-chain owner is a different wallet')}>${msg('Not Owned')}</span>` : ''}
               </td>
               <td>
                   <button
@@ -146,10 +145,6 @@ export class VehicleListItemElement extends BaseOnboardingElement {
     }
 
     getConnectionStatus(item: Vehicle): ConnectionStatus {
-        if (!item.isCurrentUserOwner && item.tokenId !== 0) {
-            return ConnectionStatus.TRANSFERRED;
-        }
-
         if (["inQueue", "inProgress"].includes(item.disconnectionStatus)) {
             return ConnectionStatus.DISCONNECTING;
         }
@@ -178,18 +173,22 @@ export class VehicleListItemElement extends BaseOnboardingElement {
     }
 
     getConnectionCSSClass(item: Vehicle): string {
-        const status = this.getConnectionStatus(item);
-        if (status === ConnectionStatus.TRANSFERRED) {
-            return "status status-transferred";
-        }
-        return status === ConnectionStatus.CONNECTED ? "status status-connected" : "status status-offline";
+        return this.getConnectionStatus(item) === ConnectionStatus.CONNECTED ? "status status-connected" : "status status-offline";
+    }
+
+    // True when the vehicle is on-chain (minted) but neither owned by the current user
+    // nor controlled via a shared kernel account they signed for.
+    isExternallyOwned(item: Vehicle): boolean {
+        return item.tokenId !== 0 && !item.isCurrentUserOwner && !item.isSharedAccountSigner;
     }
 
     canConnect(item: Vehicle): boolean {
+        if (!item.isCurrentUserOwner) return false;
         return [ConnectionStatus.UNKNOWN, ConnectionStatus.DISCONNECTED, ConnectionStatus.CONNECTION_FAILED].includes(this.getConnectionStatus(item));
     }
 
     canDisconnect(item: Vehicle): boolean {
+        if (!item.isCurrentUserOwner) return false;
         return [ConnectionStatus.CONNECTED, ConnectionStatus.DISCONNECTION_FAILED].includes(this.getConnectionStatus(item));
     }
 

--- a/web/src/global-styles.ts
+++ b/web/src/global-styles.ts
@@ -408,9 +408,10 @@ export const globalStyles = css`
         color: #856404;
     }
 
-    .status-transferred {
+    .status-not-owned {
         background: #ffe5b4;
         color: #856404;
+        margin-left: 4px;
     }
 
     .status-blocked {


### PR DESCRIPTION
## Summary
The onboarding vehicle row's status badge conflated **connection state** with **on-chain ownership**. `TRANSFERRED` short-circuited `getConnectionStatus()`, which meant:

- A vehicle owned by a shared kernel account the tenant signed for was labeled **"Transferred"** — even though the tenant could still drive it (transfer button is shown, badge claimed otherwise).
- A genuinely externally-owned vehicle showed *only* "Transferred"; you couldn't tell if telemetry was still flowing.

## What changed
- `TRANSFERRED` removed from the `ConnectionStatus` enum and label switch.
- `getConnectionStatus()` now reports pure connection state.
- New `isExternallyOwned(item)` helper: minted **and** not the current user **and** not a shared signer.
- `canConnect()` / `canDisconnect()` now explicitly require `isCurrentUserOwner`, preserving previous button-hiding behavior that used to come from `TRANSFERRED` short-circuiting these to `false`. `canDelete()` already had this check.
- Status cell renders the real connection badge always; an additional **"Not Owned"** badge appears next to it when `isExternallyOwned()` is true.
- CSS class renamed `.status-transferred` → `.status-not-owned`, with `margin-left: 4px` so the two badges have breathing room.

## Behavior matrix

| Vehicle state | Before | After |
|---|---|---|
| Owned, connected | "Connected" (green) | "Connected" (green) |
| Owned, disconnected | "Disconnected" (offline) | "Disconnected" (offline) |
| Shared-signer, connected | "Transferred" (orange) | "Connected" (green) |
| Truly external, connected | "Transferred" (orange) | "Connected" + "Not Owned" |
| Truly external, disconnected | "Transferred" (orange) | "Disconnected" + "Not Owned" |

Button visibility unchanged: owner-gated actions (connect/disconnect/delete) stay hidden for externally-owned vehicles; transfer is shown for owner-or-signer; force-delete is shown for non-owners.

## Test plan
- [ ] Owned vehicle, connected — single green "Connected" badge.
- [ ] Owned vehicle, freshly disconnected — single offline "Disconnected" badge.
- [ ] Shared-signer vehicle, connected — green "Connected" badge, no "Not Owned" badge, transfer button works.
- [ ] Externally-owned vehicle (truly transferred away) — connection badge reflects real state, "Not Owned" badge appears next to it, force-delete is the only visible action.
- [ ] Confirm tooltip "On-chain owner is a different wallet" appears on the "Not Owned" badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)