### PR TITLE
fix(documents): drop filehash from fetch-api CloudEventHeader selection

### DIFF
--- a/web/src/services/document-service.ts
+++ b/web/src/services/document-service.ts
@@ -83,6 +83,10 @@ export async function fetchVehicleAttestations(tokenDID: string): Promise<Attest
     }>(
         'POST',
         `/fleet/vehicles/fetch?did=${encodeURIComponent(tokenDID)}`,
+        // NOTE: fetch-api removed `filehash` from CloudEventHeader (it's now a CE
+        // extension attribute, not a header field), so selecting `header { filehash }`
+        // 422s with "Cannot query field \"filehash\" on type \"CloudEventHeader\"".
+        // We rely on each CE's own presigned `dataUrl` for downloads instead.
         `{
             cloudEvents(did: "${tokenDID}", limit: 40, filter: { type: "${type}" }) {
                 header {
@@ -95,7 +99,6 @@ export async function fetchVehicleAttestations(tokenDID: string): Promise<Attest
                     producer
                     datacontenttype
                     tags
-                    filehash
                 }
                 data
                 dataUrl


### PR DESCRIPTION
## Problem
The vehicle documents panel is fully broken in any environment: every per-type `cloudEvents` query 422s with

```
Cannot query field "filehash" on type "CloudEventHeader"
```

fetch-api removed `filehash` from its GraphQL `CloudEventHeader` type — it's now a CloudEvent **extension attribute**, not a header field (confirmed against `cloudevent@v0.1.6`, whose header struct has no `filehash`, only an `Extras` map). The query in `document-service.ts` still selected `header { … filehash }`, so the whole `fetchVehicleAttestations` call fails and no attestations load.

This query is forwarded verbatim by kaufmann-oracle's `POST /v1/fleet/vehicles/fetch` proxy, which is why the 422 surfaces in kaufmann's logs (mislabeled "identity api" by the shared HTTP client — fixed separately in kaufmann-oracle).

## Fix
Remove `filehash` from the `header { }` selection. That stops the 422 and restores the documents panel.

## Download behavior
`filehash` was the key linking a parsed doc to its raw CE's presigned `dataUrl` (the large-file fallback in `resolveDownloadUrl`). With it gone:
- Downloads use each CE's own `dataUrl` (covers inline/small docs) ✅
- The `rawByFilehash` raw-pairing fallback is no longer populated — large docs whose bytes live only on the raw CE lose that fallback.

**Follow-up:** re-key the raw↔parsed pairing against the new schema (read the hash from the parsed CE's `data`, or via the CE extension attrs if fetch-api exposes them). Not done here to avoid guessing the new location.

## Verification
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)