### PR TITLE
feat(reports): run feedback panel, polling timeout, and make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+# b2b-fleet-mgr-app — root Makefile for local development.
+#
+# `make dev` is the one-command path for a new developer: it checks the dev
+# host is in /etc/hosts, ensures api/settings.yaml exists with USE_DEV_CERTS
+# enabled, installs web deps, then brings up the frontend (Vite + mkcert) and
+# the backend (Go) together. Ctrl-C tears both down.
+#
+# Unlike fleet-lite-app there is no local database — this app proxies to remote
+# DIMO dev APIs, so there are no `db`/`migrate` targets.
+#
+# See README.md for the manual, step-by-step equivalent.
+
+SHELL    := /bin/bash
+DEV_HOST := localdev.dimo.org
+WEB_PORT := 3008
+API_PORT := 3007
+
+.DEFAULT_GOAL := help
+.PHONY: dev help check-host settings web-install web api
+
+## dev: bring up frontend + backend together (one-command local dev)
+dev: check-host settings web-install
+	@scripts/dev-up.sh
+
+## check-host: verify $(DEV_HOST) resolves to localhost via /etc/hosts
+# NB: we deliberately do NOT use nslookup here — on macOS it queries DNS only
+# and ignores /etc/hosts, so it returns NXDOMAIN even when the entry is present.
+# dscacheutil (macOS) / getent (Linux) both consult /etc/hosts.
+check-host:
+	@ip="$$(getent ahostsv4 $(DEV_HOST) 2>/dev/null | awk 'NR==1{print $$1}')"; \
+	if [ -z "$$ip" ]; then \
+	  ip="$$(dscacheutil -q host -a name $(DEV_HOST) 2>/dev/null | awk '/^ip_address:/{print $$2; exit}')"; \
+	fi; \
+	if [ "$$ip" = "127.0.0.1" ] || [ "$$ip" = "::1" ]; then \
+	  echo "✓ $(DEV_HOST) → $$ip"; \
+	else \
+	  echo "✗ $(DEV_HOST) does not resolve to localhost (got: $${ip:-nothing})."; \
+	  echo "  Add it to /etc/hosts, then flush the DNS cache:"; \
+	  echo "    echo '127.0.0.1 $(DEV_HOST)' | sudo tee -a /etc/hosts"; \
+	  echo "    sudo killall -HUP mDNSResponder"; \
+	  exit 1; \
+	fi
+
+## settings: ensure api/settings.yaml exists and uses dev TLS certs
+# Local dev needs USE_DEV_CERTS: true so the Go backend serves HTTPS with the
+# mkcert certs (the frontend calls https://$(DEV_HOST):$(API_PORT)). The sample
+# ships with it false, so we create-from-sample if missing and flip it on.
+settings:
+	@if [ ! -f api/settings.yaml ]; then \
+	  cp api/settings.sample.yaml api/settings.yaml; \
+	  echo "✓ created api/settings.yaml from sample"; \
+	else \
+	  echo "✓ api/settings.yaml present"; \
+	fi
+	@if grep -qi '^USE_DEV_CERTS: *false' api/settings.yaml; then \
+	  sed -i.bak 's/^USE_DEV_CERTS: *false/USE_DEV_CERTS: true/I' api/settings.yaml && rm -f api/settings.yaml.bak; \
+	  echo "✓ set USE_DEV_CERTS: true (required for local HTTPS)"; \
+	fi
+
+## web-install: install frontend dependencies if missing
+web-install:
+	@if [ ! -d web/node_modules ]; then \
+	  echo "▶ installing web deps…"; cd web && npm install; \
+	else \
+	  echo "✓ web deps present (run 'cd web && npm install' to refresh)"; \
+	fi
+
+## web: run only the frontend (Vite dev server, generates mkcert certs)
+web: check-host web-install
+	@cd web && npm run dev
+
+## api: run only the backend (requires certs from a running/previous 'make web')
+api: settings
+	@cd api && go run ./cmd/fleet-onboard-app
+
+## help: list targets
+help:
+	@echo "b2b-fleet-mgr-app — local dev"
+	@echo ""
+	@echo "  make dev          bring up frontend + backend together (start here)"
+	@echo "  make check-host   verify $(DEV_HOST) is in /etc/hosts"
+	@echo "  make settings     ensure api/settings.yaml exists with USE_DEV_CERTS: true"
+	@echo "  make web          run only the frontend  (https://$(DEV_HOST):$(WEB_PORT))"
+	@echo "  make api          run only the backend   (https://$(DEV_HOST):$(API_PORT))"
+	@echo ""
+	@echo "No local database — this app proxies to remote DIMO dev APIs."
+	@echo "First run also needs the mkcert root CA trusted — Vite installs it on"
+	@echo "first 'npm run dev' (one-time sudo prompt)."

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ Can also serve as an example for developers wanting to build onboarding flows on
 
 ## Running locally
 
+### Quick start
+
+```
+make dev
+```
+
+This is the one-command path: it checks `localdev.dimo.org` is in your hosts
+file, ensures `api/settings.yaml` exists with `USE_DEV_CERTS: true`, installs web
+deps if needed, then brings up the frontend (Vite + mkcert) and the Go backend
+together. Ctrl-C tears both down. Run `make help` to see all targets
+(`make web` / `make api` run either half alone).
+
+First run still needs the prerequisites below — a hosts-file entry and the
+mkcert root CA trusted (Vite installs the CA on first run, a one-time sudo
+prompt). For features that need signing you'll also need the zerodev/RPC URLs
+and keys in `api/settings.yaml`.
+
+### Manual steps
+
 1. Modify your hosts file to add a 127.0.0.1 entry for localdev.dimo.org . This should exist in the equivalent app configured in dimo dev console. 
 
 2. Start the web app in the `web` folder. Install dependencies `$ npm i`, then start the vite server `$ npm run dev`.

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Runtime half of `make dev`: start the Vite frontend (which generates the
+# mkcert dev certificates under web/.mkcert), wait for those certs to appear,
+# then start the Go backend in the foreground. The backend serves TLS using
+# the same certs (see api/.../main.go runFiber), so the frontend's
+# https://localdev.dimo.org:3007 API calls work. Both run together; Ctrl-C
+# tears the whole tree down cleanly.
+#
+# Prerequisites (host check, settings, web deps) are handled by the Makefile
+# targets that run before this script.
+
+set -euo pipefail
+
+# Run from the repo root regardless of where the script was invoked from.
+cd "$(dirname "$0")/.."
+
+CERT="web/.mkcert/cert.pem"
+KEY="web/.mkcert/dev.pem"   # vite-plugin-mkcert emits the key as dev.pem
+DEV_HOST="localdev.dimo.org"
+WEB_PORT="3008"
+API_PORT="3007"
+
+# Recursively kill a process and all of its descendants (npm -> vite -> esbuild).
+# pgrep -P is available on both macOS and Linux.
+killtree() {
+  local pid="$1"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    killtree "$child"
+  done
+  kill "$pid" 2>/dev/null || true
+}
+
+WEB_PID=""
+cleanup() {
+  if [ -n "$WEB_PID" ]; then
+    echo
+    echo "▶ shutting down frontend…"
+    killtree "$WEB_PID"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+echo "▶ starting frontend (Vite + mkcert) on https://$DEV_HOST:$WEB_PORT …"
+( cd web && npm run dev ) &
+WEB_PID=$!
+
+echo "▶ waiting for dev TLS certs ($CERT)…"
+until [ -f "$CERT" ] && [ -f "$KEY" ]; do
+  if ! kill -0 "$WEB_PID" 2>/dev/null; then
+    echo "✗ frontend exited before generating certs — see its output above." >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+echo "✓ dev certs present"
+
+echo "▶ starting backend (api on https://$DEV_HOST:$API_PORT)…"
+# Foreground: when this exits (or Ctrl-C), the EXIT trap stops the frontend.
+( cd api && go run ./cmd/fleet-onboard-app )

--- a/web/src/views/reports.ts
+++ b/web/src/views/reports.ts
@@ -38,6 +38,35 @@ export class ReportsView extends LitElement {
         0% { transform: rotate(0deg); }
         100% { transform: rotate(360deg); }
       }
+      .run-feedback {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .run-feedback-main {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .run-feedback-status {
+        font-weight: bold;
+        opacity: 0.85;
+      }
+      .run-feedback-dismiss {
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-size: 16px;
+        line-height: 1;
+        color: inherit;
+        padding: 0 4px;
+        flex-shrink: 0;
+      }
+      .run-feedback-dismiss:hover {
+        opacity: 0.7;
+      }
     ` ];
 
   @state()
@@ -78,6 +107,9 @@ export class ReportsView extends LitElement {
 
   private pollingIntervals: Map<string, number> = new Map();
 
+  // Timestamp (ms) after which polling for a given report gives up.
+  private pollingDeadlines: Map<string, number> = new Map();
+
   @state()
   private selectedFormat: 'csv' | 'xlsx' = 'xlsx';
 
@@ -90,7 +122,19 @@ export class ReportsView extends LitElement {
   @state()
   private highlightReportId: string | null = null;
 
+  // Report just launched from the RUN REPORT button — keeps the button disabled
+  // until polling reaches a terminal state (completed / failed).
+  @state()
+  private activeRunReportId: string | null = null;
+
+  // Feedback panel shown above the report area when a report is launched.
+  @state()
+  private runFeedback: { tone: 'processing' | 'success' | 'error'; message: string } | null = null;
+
   private static readonly MAX_RANGE_DAYS = 366;
+
+  // Give up polling a report after this long and surface a timeout error.
+  private static readonly POLLING_TIMEOUT_MS = 15 * 60 * 1000;
 
   async connectedCallback() {
     super.connectedCallback();
@@ -127,6 +171,16 @@ export class ReportsView extends LitElement {
           updatedAt: new Date().toISOString(),
         };
         this.reports = [placeholder, ...this.reports];
+      }
+      // Reflect feedback for the redirected report unless it already finished.
+      const highlighted = this.reports.find(r => r.id === this.highlightReportId);
+      const status = highlighted?.status.toLowerCase();
+      if (status !== 'completed' && status !== 'failed' && status !== 'error') {
+        this.activeRunReportId = this.highlightReportId;
+        this.runFeedback = {
+          tone: 'processing',
+          message: msg('Your report is being processed. This may take a moment…'),
+        };
       }
       this.startPolling(this.highlightReportId);
       await this.updateComplete;
@@ -257,10 +311,11 @@ export class ReportsView extends LitElement {
   }
 
   private async handleRunReport() {
-    if (!this.selectedTemplate || this.submitting) return;
+    if (!this.selectedTemplate || this.submitting || this.activeRunReportId) return;
     if (this.getDateRangeError()) return;
 
     this.submitting = true;
+    this.runFeedback = { tone: 'processing', message: msg('Submitting report…') };
     try {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
       console.log('Running report using timezone:', timezone);
@@ -296,12 +351,29 @@ export class ReportsView extends LitElement {
         };
 
         this.reports = [newReport, ...this.reports];
-        
+
+        // Track this report so the RUN REPORT button stays disabled and the
+        // feedback panel reflects live polling status until it finishes.
+        this.activeRunReportId = result.reportId;
+        this.runFeedback = {
+          tone: 'processing',
+          message: msg('Your report is being processed. This may take a moment…'),
+        };
+
         // Start polling for this report
         this.startPolling(result.reportId);
+      } else {
+        this.runFeedback = {
+          tone: 'error',
+          message: msg('Could not start the report. Please try again.'),
+        };
       }
     } catch (error) {
       console.error('Failed to run report:', error);
+      this.runFeedback = {
+        tone: 'error',
+        message: msg('Failed to run report. Please try again.'),
+      };
     } finally {
       this.submitting = false;
     }
@@ -313,11 +385,24 @@ export class ReportsView extends LitElement {
     this.pollingReportIds.add(reportId);
     this.pollingReportIds = new Set(this.pollingReportIds);
 
+    this.pollingDeadlines.set(reportId, Date.now() + ReportsView.POLLING_TIMEOUT_MS);
+
     const interval = window.setInterval(async () => {
+      // Give up if the report has been processing too long.
+      const deadline = this.pollingDeadlines.get(reportId);
+      if (deadline !== undefined && Date.now() > deadline) {
+        this.stopPolling(reportId);
+        this.finishActiveRun(reportId, {
+          tone: 'error',
+          message: msg('Report timed out after 15 minutes. Please try again.'),
+        });
+        return;
+      }
+
       // Show status update effect
       this.statusUpdateEffectIds.add(reportId);
       this.statusUpdateEffectIds = new Set(this.statusUpdateEffectIds);
-      
+
       // Remove effect after 1 second
       setTimeout(() => {
         this.statusUpdateEffectIds.delete(reportId);
@@ -325,18 +410,44 @@ export class ReportsView extends LitElement {
       }, 1000);
 
       const statusUpdate = await FleetService.getInstance().getReportStatus(reportId);
-      
+
       if (statusUpdate) {
         // Update the report in the list
         this.reports = this.reports.map(r => r.id === reportId ? statusUpdate : r);
 
-        if (statusUpdate.status === 'completed') {
+        const status = statusUpdate.status.toLowerCase();
+        if (status === 'completed') {
           this.stopPolling(reportId);
+          this.finishActiveRun(reportId, {
+            tone: 'success',
+            message: msg('Your report is ready — download it from Report History below.'),
+          });
+        } else if (status === 'failed' || status === 'error') {
+          this.stopPolling(reportId);
+          this.finishActiveRun(reportId, {
+            tone: 'error',
+            message: msg('Report processing failed. Please try again.'),
+          });
         }
       }
     }, 5000);
 
     this.pollingIntervals.set(reportId, interval);
+  }
+
+  // Clears the active-run lock (re-enabling RUN REPORT) and updates the
+  // feedback panel when the launched report reaches a terminal state.
+  private finishActiveRun(
+    reportId: string,
+    feedback: { tone: 'success' | 'error'; message: string }
+  ) {
+    if (this.activeRunReportId !== reportId) return;
+    this.activeRunReportId = null;
+    this.runFeedback = feedback;
+  }
+
+  private dismissRunFeedback() {
+    this.runFeedback = null;
   }
 
   private stopPolling(reportId: string) {
@@ -345,6 +456,7 @@ export class ReportsView extends LitElement {
       window.clearInterval(interval);
       this.pollingIntervals.delete(reportId);
     }
+    this.pollingDeadlines.delete(reportId);
     this.pollingReportIds.delete(reportId);
     this.pollingReportIds = new Set(this.pollingReportIds);
   }
@@ -407,6 +519,40 @@ export class ReportsView extends LitElement {
     }
 
     return `${start.format('MMM D, YYYY')} - ${end.format('MMM D, YYYY')}`;
+  }
+
+  private renderRunFeedback() {
+    if (!this.runFeedback) return '';
+
+    const { tone, message } = this.runFeedback;
+    const alertClass = tone === 'error' ? 'alert-error' : 'alert-success';
+
+    // While processing, surface the live status reported by polling.
+    const activeReport = this.activeRunReportId
+      ? this.reports.find(r => r.id === this.activeRunReportId)
+      : undefined;
+    const liveStatus = tone === 'processing' && activeReport
+      ? activeReport.status.toUpperCase()
+      : null;
+
+    return html`
+      <div class="alert ${alertClass} run-feedback" role="status" aria-live="polite">
+        <div class="run-feedback-main">
+          ${tone === 'processing' ? html`<span class="spinner"></span>` : ''}
+          <span>${message}</span>
+          ${liveStatus ? html`
+            <span class="run-feedback-status">${msg('Status:')} ${liveStatus}</span>
+          ` : ''}
+        </div>
+        ${tone !== 'processing' ? html`
+          <button
+            class="run-feedback-dismiss"
+            aria-label="${msg('Dismiss')}"
+            @click=${this.dismissRunFeedback}
+          >✕</button>
+        ` : ''}
+      </div>
+    `;
   }
 
   render() {
@@ -497,6 +643,8 @@ export class ReportsView extends LitElement {
                 </div>
             </div>
 
+            ${this.renderRunFeedback()}
+
             <div class="reports-layout">
                 <!-- Report Templates -->
                 <div class="report-templates">
@@ -563,11 +711,11 @@ export class ReportsView extends LitElement {
                                             <option value="csv">${msg('CSV')}</option>
                                         </select>
                                         <button
-                                            class="btn btn-primary ${this.submitting ? 'processing' : ''}"
+                                            class="btn btn-primary ${this.submitting || this.activeRunReportId ? 'processing' : ''}"
                                             @click="${this.handleRunReport}"
-                                            ?disabled="${this.submitting || !this.selectedTemplate || this.selectedFleetGroupIds.length === 0 || !!dateRangeError}"
+                                            ?disabled="${this.submitting || !!this.activeRunReportId || !this.selectedTemplate || this.selectedFleetGroupIds.length === 0 || !!dateRangeError}"
                                         >
-                                            ${msg('RUN REPORT')}
+                                            ${this.activeRunReportId ? msg('PROCESSING…') : msg('RUN REPORT')}
                                         </button>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
Better feedback for the Reports "Run Report" flow, plus a one-command local dev setup.

### Reports UX
- A feedback panel now appears above the report area when you click **RUN REPORT**:
  - **Processing** — spinner + message + a live **Status:** line reflecting each poll.
  - **Success** — dismissable green panel once the report completes.
  - **Error** — dismissable red panel on submit failure or a `failed`/`error` poll status.
  - **Timeout** — after **15 minutes** of polling, gives up and shows an error in the same panel.
- **RUN REPORT stays disabled** for the entire processing lifetime (not just the POST), re-enabling on any terminal state (completed / failed / timeout).
- Polling now stops on `failed`/`error` statuses (previously only `completed`, so a failed report polled forever).

### Local dev
- Root `Makefile` with `make dev` (one-command frontend + backend), plus `make web` / `make api` / `make check-host` / `make settings`.
- `scripts/dev-up.sh` starts Vite (generates mkcert certs), waits for them, then starts the Go backend serving TLS with the same certs.
- README updated with a Quick start section.

## Test plan
- `tsc --noEmit` clean; `eslint src` 7 warnings (pre-existing `no-console`, under CI's 500 cap); `npm run build` passes.
- `make help` / `make check-host` / `make settings` verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)