### PR TITLE
feat(reports): add searchable filter for fleet groups

### DIFF
--- a/web/src/views/reports.ts
+++ b/web/src/views/reports.ts
@@ -106,6 +106,9 @@ export class ReportsView extends LitElement {
   private selectedFleetGroupIds: string[] = [];
 
   @state()
+  private fleetGroupSearch: string = '';
+
+  @state()
   private pollingReportIds: Set<string> = new Set();
 
   @state()
@@ -368,9 +371,28 @@ export class ReportsView extends LitElement {
     this.selectedFormat = (e.target as HTMLSelectElement).value as 'csv' | 'xlsx';
   }
 
+  // Fleet groups matching the current search box (case-insensitive substring).
+  private get filteredFleetGroups(): FleetGroup[] {
+    const q = this.fleetGroupSearch.trim().toLowerCase();
+    if (!q) return this.fleetGroups;
+    return this.fleetGroups.filter(g => g.name.toLowerCase().includes(q));
+  }
+
+  private handleFleetGroupSearchInput(e: Event) {
+    this.fleetGroupSearch = (e.target as HTMLInputElement).value;
+  }
+
   private handleFleetGroupChange(e: Event) {
     const select = e.target as HTMLSelectElement;
-    this.selectedFleetGroupIds = Array.from(select.selectedOptions).map(opt => opt.value);
+    // The native select only knows about the currently-rendered (filtered)
+    // options, so merge: keep prior selections hidden by the filter, and
+    // replace the selection state of the visible ones with what's selected now.
+    const visibleIds = new Set(this.filteredFleetGroups.map(g => g.id));
+    const nowSelectedVisible = new Set(Array.from(select.selectedOptions).map(opt => opt.value));
+    this.selectedFleetGroupIds = [
+      ...this.selectedFleetGroupIds.filter(id => !visibleIds.has(id)),
+      ...this.filteredFleetGroups.filter(g => nowSelectedVisible.has(g.id)).map(g => g.id),
+    ];
   }
 
   private async handleRunReport() {
@@ -737,13 +759,27 @@ export class ReportsView extends LitElement {
                     <div class="report-config">
                         <div class="form-row" style="align-items: flex-start;">
                             <div class="form-group" style="flex:1; display: flex; flex-direction: column;">
-                                <label class="form-label">${msg('Fleet Groups (ctrl+click to select multiple)')}</label>
+                                <label class="form-label">
+                                    ${msg('Fleet Groups (ctrl+click to select multiple)')}
+                                    ${this.selectedFleetGroupIds.length > 0 ? html`<span style="color:#666; font-weight:normal;"> — ${this.selectedFleetGroupIds.length} ${msg('selected')}</span>` : ''}
+                                </label>
+                                <input
+                                    type="text"
+                                    class="search-box"
+                                    style="width: 100%; margin: 0 0 6px 0; font-size: 14px; padding: 5px 10px;"
+                                    .placeholder=${msg('Search fleet groups...')}
+                                    .value=${this.fleetGroupSearch}
+                                    @input=${this.handleFleetGroupSearchInput}
+                                >
                                 <select multiple style="width: 100%; flex: 1; min-height: 120px;" @change="${this.handleFleetGroupChange}">
-                                    ${this.fleetGroups.map(group => html`
-                                        <option value="${group.id}" ?disabled=${!group.has_access}>
+                                    ${this.filteredFleetGroups.map(group => html`
+                                        <option value="${group.id}" ?disabled=${!group.has_access} ?selected=${this.selectedFleetGroupIds.includes(group.id)}>
                                             ${group.name} - ${group.vehicle_count} ${!group.has_access ? msg(' (No Access)') : ''}
                                         </option>
                                     `)}
+                                    ${this.filteredFleetGroups.length === 0 ? html`
+                                        <option disabled>${msg('No matching fleet groups')}</option>
+                                    ` : ''}
                                 </select>
                             </div>
                             <div class="form-group">


### PR DESCRIPTION
## Summary
The Fleet Groups multi-select on the Reports view is hard to use once the list gets long. This adds a search box above it with client-side, case-insensitive substring filtering.

- Renders only matching groups, with a "No matching fleet groups" placeholder.
- **Selections survive filtering.** A native `<select multiple>` only knows the options currently in the DOM, so option selected state is driven from `selectedFleetGroupIds` (`?selected`), and the change handler **merges** — preserving picks hidden by the current filter and replacing the selection state of visible ones. Search "north" → pick some, search "south" → pick more, and all are submitted.
- Added a "— N selected" hint next to the label so the running total stays visible even when the filter hides some picks.

Kept the native multi-select (just added search above); ctrl+click selection is unchanged.

## Test plan
- `tsc --noEmit` clean; `npm run build` passes; no new ESLint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)