### PR TITLE
fix: localized feedback when license plate is already taken

### DIFF
--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -1435,6 +1435,8 @@ export class VehicleDetailView extends LitElement {
       this.vehicle = { ...this.vehicle, license_plate: this.editPlateValue.trim() };
       this.editingPlate = false;
       this.successMessage = msg('License plate updated.');
+    } else if (response.status === 409) {
+      this.errorMessage = msg('This license plate is already assigned to another vehicle in your fleet.');
     } else {
       this.errorMessage = response.error || msg('Failed to update license plate.');
     }


### PR DESCRIPTION
## Description
The oracle backend now enforces unique license plates per tenant and returns **409 Conflict** when a plate is already assigned to another vehicle (DIMO-Network/kaufmann-oracle#123). The vehicle detail view's inline plate editor previously surfaced the raw backend error string; it now detects the 409 and shows a localized, specific message: *"This license plate is already assigned to another vehicle in your fleet."* The editor stays open with the user's input so they can correct and retry (existing behavior).

Note: `npm run localize:extract` is currently broken on main (pre-existing `str`-tag errors in `edit-device-definition-modal-element.ts`), so the new string falls back to English until extraction is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)