### PR TITLE
feat: client-side search for fleet groups list

### DIFF
--- a/web/src/views/vehicles-fleets.ts
+++ b/web/src/views/vehicles-fleets.ts
@@ -142,6 +142,9 @@ export class VehiclesFleetsView extends LitElement {
   private activeTab: 'vehicles-list' | 'fleet-groups' = 'vehicles-list';
 
   @state()
+  private groupSearch: string = '';
+
+  @state()
   private showCreateGroupModal: boolean = false;
 
   @state()
@@ -460,6 +463,12 @@ export class VehiclesFleetsView extends LitElement {
     }
   };
 
+  private get filteredFleetGroups(): FleetGroup[] {
+    const query = this.groupSearch.trim().toLowerCase();
+    if (!query) return this.fleetGroups;
+    return this.fleetGroups.filter(group => group.name.toLowerCase().includes(query));
+  }
+
   private handleSearchInput(e: Event) {
     const input = e.target as HTMLInputElement;
     const value = input.value;
@@ -735,6 +744,13 @@ export class VehiclesFleetsView extends LitElement {
             <div id="subtab-fleet-groups" style="display: ${this.activeTab === 'fleet-groups' ? 'block' : 'none'}">
                 <div class="toolbar">
                     <button class="btn btn-primary" @click=${this.openCreateGroupModal}>${msg('+ CREATE GROUP')}</button>
+                    <input
+                      type="text"
+                      class="search-box"
+                      .placeholder=${msg('Search groups...')}
+                      @input=${(e: Event) => { this.groupSearch = (e.target as HTMLInputElement).value; }}
+                      .value=${this.groupSearch}
+                    >
                 </div>
 
                 <div class="group-list">
@@ -742,7 +758,11 @@ export class VehiclesFleetsView extends LitElement {
                         <div style="text-align: center; padding: 2rem; color: #666;">
                             ${msg('No fleet groups yet. Click "CREATE GROUP" to add one.')}
                         </div>
-                    ` : this.fleetGroups.map(group => html`
+                    ` : this.filteredFleetGroups.length === 0 ? html`
+                        <div style="text-align: center; padding: 2rem; color: #666;">
+                            ${msg('No fleet groups match your search.')}
+                        </div>
+                    ` : this.filteredFleetGroups.map(group => html`
                         <div class="group-item">
                             <div class="group-info">
                                 <span class="group-name" style="display: flex; align-items: center; gap: 0.5rem;">


### PR DESCRIPTION
## Description
Adds a search text box next to the **+ CREATE GROUP** button on the Fleet Groups sub-tab of the vehicles-fleets view. Filtering is purely client-side: a `filteredFleetGroups` getter narrows the already-loaded groups by case-insensitive name match as you type. Shows a "No fleet groups match your search." empty state when the filter excludes everything, while keeping the original "No fleet groups yet" message when there are no groups at all.

Note: the two new `msg()` strings fall back to English until `localize:extract` is fixed on main (pre-existing `str`-tag errors in `edit-device-definition-modal-element.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)