### PR TITLE
feat: my-profile view with assigned roles and fleet access

### DIFF
--- a/web/src/elements/app-root-v2.ts
+++ b/web/src/elements/app-root-v2.ts
@@ -67,6 +67,24 @@ export class AppRootV2 extends LitElement {
                 cursor: pointer;
             }
 
+            .profile-icon-btn {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 34px;
+                height: 34px;
+                border-radius: 50%;
+                color: #555;
+                border: 1px solid #ddd;
+                background: #fff;
+                cursor: pointer;
+            }
+
+            .profile-icon-btn:hover {
+                background: #f5f5f5;
+                color: #000;
+            }
+
             .update-modal-overlay {
                 position: fixed;
                 top: 0;
@@ -220,6 +238,7 @@ export class AppRootV2 extends LitElement {
             { path: '/onboarding', render: () => html`<onboarding-view></onboarding-view>` },
             { path: '/tenant-selector', render: () => html`<tenant-selector-view></tenant-selector-view>` },
             { path: '/tenant-settings', render: () => html`<tenant-settings-view></tenant-settings-view>` },
+            { path: '/my-profile', render: () => html`<my-profile-view></my-profile-view>` },
         ]);
     }
 
@@ -357,6 +376,7 @@ export class AppRootV2 extends LitElement {
         if (path.startsWith('/emails')) return msg('Emails');
         if (path.startsWith('/tenant-selector')) return msg('Tenant Selector');
         if (path.startsWith('/tenant-settings')) return msg('Tenant Settings');
+        if (path.startsWith('/my-profile')) return msg('My Profile');
         return msg('Home');
     }
 
@@ -510,6 +530,12 @@ export class AppRootV2 extends LitElement {
                             </select>
                         </div>
                         <div class="header-right">
+                            <a class="profile-icon-btn" href="#/my-profile" title="${msg('My Profile')}" aria-label="${msg('My Profile')}">
+                                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <circle cx="12" cy="8" r="4"></circle>
+                                    <path d="M4 20c0-3.3 3.6-5 8-5s8 1.7 8 5"></path>
+                                </svg>
+                            </a>
                             <div class="user-block">
                                 <span class="user-info user-email" title="${userEmail}">${userEmail}</span>
                                 <click-to-copy-element .valueToCopy="${userWalletAddress}">

--- a/web/src/views/index.ts
+++ b/web/src/views/index.ts
@@ -11,3 +11,4 @@ export * from "./tenant-selector.ts";
 export * from "./tenant-settings.ts";
 export * from "./device-definitions.ts";
 export * from "./emails.ts";
+export * from "./my-profile.ts";

--- a/web/src/views/my-profile.ts
+++ b/web/src/views/my-profile.ts
@@ -1,0 +1,186 @@
+import { LitElement, css, html } from "lit";
+import { msg } from "@lit/localize";
+import { customElement, state } from "lit/decorators.js";
+import { globalStyles } from "../global-styles.ts";
+import { IdentityService } from "@services/identity-service";
+import { FleetService, FleetGroup } from "@services/fleet-service";
+import { ApiService } from "@services/api-service";
+
+@customElement("my-profile-view")
+export class MyProfileView extends LitElement {
+  static styles = [
+    globalStyles,
+    css`
+      .profile-container {
+        max-width: 600px;
+        margin: 0 auto;
+      }
+      .roles-grid, .fleets-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+        gap: 12px;
+        margin-top: 8px;
+      }
+      .role-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px;
+        border-radius: 4px;
+        border: 1px solid #eee;
+        font-size: 13px;
+      }
+      .role-item.assigned {
+        border-color: #bbf7d0;
+        background-color: #f0fdf4;
+      }
+      .role-item.unassigned {
+        color: #999;
+      }
+      .role-mark {
+        width: 18px;
+        text-align: center;
+        font-weight: 600;
+      }
+      .role-item.assigned .role-mark {
+        color: #16a34a;
+      }
+      .fleet-info {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+      }
+      .fleet-color {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+      }
+      .fleet-count {
+        color: #666;
+        font-size: 11px;
+      }
+      .all-fleets-note {
+        font-size: 12px;
+        color: #166534;
+        background-color: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 4px;
+        padding: 8px;
+        margin-top: 8px;
+      }
+    `,
+  ];
+
+  @state() private myPermissions: string[] = [];
+  @state() private availablePermissions: string[] = [];
+  @state() private fleetGroups: FleetGroup[] = [];
+  @state() private loading = true;
+  @state() private errorMessage = "";
+
+  private identityService = IdentityService.getInstance();
+  private fleetService = FleetService.getInstance();
+  private apiService = ApiService.getInstance();
+
+  async connectedCallback() {
+    super.connectedCallback();
+    await this.fetchData();
+  }
+
+  private async fetchData() {
+    this.loading = true;
+    try {
+      const [mine, available, fleets] = await Promise.all([
+        this.identityService.getUserPermissions(),
+        this.identityService.getAvailablePermissions(),
+        this.fleetService.getFleetGroups(),
+      ]);
+      this.myPermissions = mine || [];
+      this.availablePermissions = available || [];
+      this.fleetGroups = fleets || [];
+    } catch (error) {
+      console.error("Failed to load profile data:", error);
+      this.errorMessage = msg("Failed to load your profile data.");
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  render() {
+    if (this.loading) {
+      return html`<div class="page active"><div class="panel"><div class="panel-body">${msg("Loading your profile...")}</div></div></div>`;
+    }
+
+    const email = localStorage.getItem("email") || "";
+    const wallet = this.apiService.getWalletAddress() || "";
+    const hasViewAllFleets = this.myPermissions.includes("view_all_fleets");
+    const accessibleGroups = this.fleetGroups.filter(g => g.has_access);
+
+    return html`
+      <div class="page active">
+        <div class="section-header">
+          <span>${msg("My Profile")}</span>
+        </div>
+
+        <div class="panel profile-container">
+          <div class="panel-body">
+            ${this.errorMessage ? html`<div class="alert alert-error">${this.errorMessage}</div>` : ""}
+
+            <div class="form-group">
+              <label class="form-label">${msg("Email")}</label>
+              <div style="padding: 8px 0;">${email || "N/A"}</div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">${msg("Wallet Address")}</label>
+              <div style="padding: 8px 0; font-family: monospace;">${wallet}</div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">${msg("Roles")}</label>
+              <div class="roles-grid">
+                ${this.availablePermissions.map((perm) => {
+                  const assigned = this.myPermissions.includes(perm);
+                  return html`
+                    <div class="role-item ${assigned ? "assigned" : "unassigned"}">
+                      <span class="role-mark">${assigned ? "✓" : "—"}</span>
+                      <span>${perm}</span>
+                    </div>
+                  `;
+                })}
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">${msg("Fleet Group Access")}</label>
+              ${hasViewAllFleets
+                ? html`<div class="all-fleets-note">${msg("You can view all fleet groups in this tenant.")}</div>`
+                : accessibleGroups.length === 0
+                  ? html`<div style="padding: 8px 0; color: #666;">${msg("You don't have access to any fleet groups. Contact your administrator.")}</div>`
+                  : ""}
+              <div class="fleets-grid">
+                ${(hasViewAllFleets ? this.fleetGroups : accessibleGroups).map(
+                  (fleet) => html`
+                    <div class="role-item assigned">
+                      <span class="fleet-info">
+                        <span class="fleet-color" style="background-color: ${fleet.color}"></span>
+                        <span>${fleet.name}</span>
+                        <span class="fleet-count">(${fleet.vehicle_count} ${msg("vehicles")})</span>
+                      </span>
+                    </div>
+                  `
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "my-profile-view": MyProfileView;
+  }
+}


### PR DESCRIPTION
## Description
Makes it easy for the signed-in user to see what they can do and which fleets they can see. A round profile icon now sits in the top-right header, to the left of the email/wallet block, with a "My Profile" tooltip on hover. It links to a new read-only `#/my-profile` view showing:

- **Email and wallet** of the signed-in user
- **Roles**: every available role (`GET /account/permissions-available`) with a green ✓ when assigned (`GET /permissions`) and a grayed — when not
- **Fleet Group Access**: the groups the user can access from `GET /fleet/groups` `has_access`; users with `view_all_fleets` see a note that they can view all groups (with the full list), and users with no access get a "contact your administrator" hint

No backend changes needed — all three endpoints already existed. New `msg()` strings fall back to English until `localize:extract` is fixed on main (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)