### PR TITLE
fix: profile icon click navigates to my-profile view

### DIFF
--- a/web/src/elements/app-root-v2.ts
+++ b/web/src/elements/app-root-v2.ts
@@ -451,10 +451,10 @@ export class AppRootV2 extends LitElement {
             <div class="app-container">
                 <!-- Sidebar -->
                 <aside class="sidebar">
-                    <div class="sidebar-header" @click=${this.onSidebarClick}>
+                    <div class="sidebar-header" @click=${this.onNavLinkClick}>
                         <img src="/assets/dimo-logo-d.png" alt="DIMO" class="logo" />
                     </div>
-                    <nav class="sidebar-nav" @click=${this.onSidebarClick}>
+                    <nav class="sidebar-nav" @click=${this.onNavLinkClick}>
                         <div class="nav-item ${this.isActive('/') ? 'active' : ''}" data-page="home">
                             <a data-page="home" href="#/" aria-current="${this.isActive('/') ? 'page' : 'false'}">${msg('Home')}</a>
                         </div>
@@ -530,7 +530,7 @@ export class AppRootV2 extends LitElement {
                             </select>
                         </div>
                         <div class="header-right">
-                            <a class="profile-icon-btn" href="#/my-profile" title="${msg('My Profile')}" aria-label="${msg('My Profile')}">
+                            <a class="profile-icon-btn" href="#/my-profile" @click=${this.onNavLinkClick} title="${msg('My Profile')}" aria-label="${msg('My Profile')}">
                                 <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                     <circle cx="12" cy="8" r="4"></circle>
                                     <path d="M4 20c0-3.3 3.6-5 8-5s8 1.7 8 5"></path>
@@ -590,8 +590,11 @@ export class AppRootV2 extends LitElement {
         `;
     }
 
-    private onSidebarClick = async (e: MouseEvent) => {
-        // Delegate anchor clicks to ensure hash navigation triggers our router.
+    // Delegated click handler for hash-link anchors (sidebar nav and header icons).
+    // preventDefault is load-bearing: without it, @lit-labs/router's global click
+    // interceptor takes the click, pushStates the href (no hashchange event) and
+    // routes by anchor.pathname — which is always "/" for hash links, rendering Home.
+    private onNavLinkClick = async (e: MouseEvent) => {
         const target = e.target as HTMLElement | null;
         const anchor = target?.closest?.('a[href^="#"]') as HTMLAnchorElement | null;
         if (!anchor || anchor.closest('.nav-item.disabled')) return;


### PR DESCRIPTION
## Description
Clicking the My Profile icon updated the URL hash but kept rendering Home; pasting the URL and hitting Enter worked. Root cause is in `@lit-labs/router`'s `Router` class, which installs a **global window click interceptor**: for any same-origin anchor click that isn't default-prevented it calls `history.pushState(...)` (URL bar updates but **no `hashchange` event** fires) and then `goto(anchor.pathname)` — and `pathname` is always `/` for hash-only links, so it rendered the Home route.

The sidebar links never hit this because `onSidebarClick` (a delegated handler) calls `preventDefault()` — which makes the router's interceptor bail — and then sets `location.hash` itself, triggering the app's `hashchange` → `router.goto(path)` flow. The profile icon anchor was missing that handler.

### Changes made:
- Attach the existing delegated nav handler to the profile icon anchor.
- Rename `onSidebarClick` → `onNavLinkClick` (it now serves both sidebar and header) and document why the `preventDefault` is load-bearing.

Verified: `tsc` clean, eslint clean, production build succeeds. (Couldn't live-verify in Chrome — navigation permission to fleet-onboard.dimo.org was denied in the connected session — but the failing mechanism is read directly from `@lit-labs/router`'s source, and the fix is exactly the mechanism the working sidebar links already use.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)