### PR TITLE
fix: register R1 sync route in b2b proxy

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -106,6 +106,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	oracleApp.Get("/fleet/vehicles", genericProxyCtrl.Proxy)
 	oracleApp.Get("/fleet/vehicles/apimaz/:vin", genericProxyCtrl.Proxy)
 	oracleApp.Post("/fleet/vehicles/apimaz/:vin/sync", genericProxyCtrl.Proxy)
+	oracleApp.Post("/fleet/vehicles/r1/sync", genericProxyCtrl.Proxy)
 	oracleApp.Patch("/fleet/vehicles/:tokenID/license-plate", genericProxyCtrl.Proxy)
 	oracleApp.Get("/fleet/vehicles/:tokenID", genericProxyCtrl.Proxy)
 	oracleApp.Get("/fleet/vehicles/telemetry-info/:tokenID", genericProxyCtrl.Proxy)


### PR DESCRIPTION
## Description
The b2b API proxies only explicitly registered routes to the oracle. #137's R1 Devices panel calls `POST /fleet/vehicles/r1/sync`, which wasn't in the allowlist, so it hit the fall-through 404 (`proxy_route_not_registered`). Registers the route alongside the other vehicle sync proxies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)