### PR TITLE
fix(web): guard against null GPS coordinates in vehicle telemetry

### DIFF
--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -26,13 +26,13 @@ dayjs.extend(relativeTime);
 
 interface TelemetryInfo {
   signalsLatest: {
-    currentLocationCoordinates: {
-      value: {
+    currentLocationCoordinates?: {
+      value?: {
         latitude: number;
         longitude: number;
-      };
+      } | null;
       timestamp: string;
-    };
+    } | null;
     obdIsEngineBlocked: {
       value: number | null;
       timestamp: string;
@@ -764,7 +764,7 @@ export class VehicleDetailView extends LitElement {
               </div>
               <div style="text-align: right;">
                 <div style="color: #666; font-size: 10px;">${msg('LAST TELEMETRY')}</div>
-                <div>${this.lastTelemetry ? this.formatLastTelemetry(this.lastTelemetry.signalsLatest.currentLocationCoordinates.timestamp) : msg('Loading...')}</div>
+                <div>${this.lastTelemetry ? this.formatLastTelemetry(this.lastTelemetry.signalsLatest.currentLocationCoordinates?.timestamp) : msg('Loading...')}</div>
                 <div style="color: #666; font-size: 10px; margin-top: 12px;">${msg('HARDWARE')}</div>
                 <div>${this.renderHardwareDetails()}</div>
               </div>
@@ -885,19 +885,19 @@ export class VehicleDetailView extends LitElement {
               </div>
               <div class="panel-body">
                 <fleet-map class="map-placeholder"
-                    .lat="${this.lastTelemetry?.signalsLatest.currentLocationCoordinates.value.latitude ?? 0.0}"
-                    .lng="${this.lastTelemetry?.signalsLatest.currentLocationCoordinates.value.longitude ?? 0.0}"
+                    .lat="${this.lastTelemetry?.signalsLatest.currentLocationCoordinates?.value?.latitude ?? 0.0}"
+                    .lng="${this.lastTelemetry?.signalsLatest.currentLocationCoordinates?.value?.longitude ?? 0.0}"
                     .routePoints=${this.tripRoutePoints}
                     @address-updated=${this.handleAddressUpdated}>
                 </fleet-map>
                 <div class="mt-16">
                   <div class="detail-row">
                     <span class="detail-label">${msg('Latitude')}</span>
-                    <span class="detail-value">${this.lastTelemetry?.signalsLatest.currentLocationCoordinates.value.latitude ?? 0.0}</span>
+                    <span class="detail-value">${this.lastTelemetry?.signalsLatest.currentLocationCoordinates?.value?.latitude ?? 0.0}</span>
                   </div>
                   <div class="detail-row">
                     <span class="detail-label">${msg('Longitude')}</span>
-                    <span class="detail-value">${this.lastTelemetry?.signalsLatest.currentLocationCoordinates.value.longitude ?? 0.0}</span>
+                    <span class="detail-value">${this.lastTelemetry?.signalsLatest.currentLocationCoordinates?.value?.longitude ?? 0.0}</span>
                   </div>
                   <div class="detail-row">
                     <span class="detail-label">${msg('Address')}</span>

--- a/web/src/views/vehicles-fleets.ts
+++ b/web/src/views/vehicles-fleets.ts
@@ -37,20 +37,20 @@ interface Vehicle {
 
 interface TelemetrySignals {
   signalsLatest: {
-    currentLocationCoordinates: {
-      value: {
+    currentLocationCoordinates?: {
+      value?: {
         latitude: number;
         longitude: number;
-      };
+      } | null;
       timestamp: string;
-    };
-    obdIsEngineBlocked: {
+    } | null;
+    obdIsEngineBlocked?: {
       value: number;
       timestamp: string;
-    };
-    powertrainTransmissionTravelledDistance: {
+    } | null;
+    powertrainTransmissionTravelledDistance?: {
       value: number;
-    };
+    } | null;
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes an unhandled promise rejection on the vehicle detail view (`#/vehicles/:tokenId`):

```
TypeError: null is not an object (evaluating
'this.lastTelemetry.signalsLatest.currentLocationCoordinates.timestamp')
```

### Root cause
The `TelemetryInfo` / `TelemetrySignals` types declared `signalsLatest.currentLocationCoordinates` (and its nested `value`) as always-present, but the backend returns `null` for these when a vehicle has never reported GPS. Because the types lied, TypeScript did not flag the unguarded chains, and the access threw at runtime.

### Changes
- **`vehicle-detail.ts`** — the actual crash. Made `currentLocationCoordinates` and `value` optional/nullable in the type, and added optional chaining at all five coordinate access sites (line 767 was the crash; lines 888/889/896/900 had the same latent bug).
- **`vehicles-fleets.ts`** — access sites were already defensive (`?.`), but aligned the type to be honest so the compiler stays a safety net.
- **`tracking-app.ts`** — already had the correct nullable type and defensive access; unchanged.

## Test
- `npx tsc --noEmit` passes
- `npx eslint` on changed files: no errors (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)