### PR TITLE
feat(vehicle): shared-account disconnect and delete (proxy + UI)

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -147,6 +147,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	// Disconnect vehicle
 	oracleApp.Get("/vehicle/disconnect", genericProxyCtrl.Proxy)
 	oracleApp.Post("/vehicle/disconnect", vehiclesCtrl.SubmitDisconnectData)
+	oracleApp.Post("/vehicle/disconnect/shared", vehiclesCtrl.SubmitSharedAccountDisconnect)
 	oracleApp.Get("/vehicle/disconnect/status", vehiclesCtrl.GetDisconnectStatus)
 
 	// Transfer vehicle
@@ -158,6 +159,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	// Delete vehicle
 	oracleApp.Get("/vehicle/delete", vehiclesCtrl.GetDeleteData)
 	oracleApp.Post("/vehicle/delete", vehiclesCtrl.SubmitDeleteData)
+	oracleApp.Post("/vehicle/delete/shared", vehiclesCtrl.SubmitSharedAccountDelete)
 	oracleApp.Get("/vehicle/delete/status", vehiclesCtrl.GetDeleteStatus)
 
 	oracleApp.Get("/vehicle/:vin", vehiclesCtrl.GetVehicleFromOracle)

--- a/api/internal/controllers/vehicles.go
+++ b/api/internal/controllers/vehicles.go
@@ -212,6 +212,26 @@ func (v *VehiclesController) SubmitSharedAccountTransfer(c *fiber.Ctx) error {
 	return ProxyRequest(c, targetURL, c.Body(), v.logger)
 }
 
+// SubmitSharedAccountDisconnect forwards the server-signed disconnect request to the kaufmann
+// oracle endpoint that burns the synthetic device on behalf of a shared kernel account using
+// the tenant signer. Body: { tokenId }. Response: { jobId }.
+func (v *VehiclesController) SubmitSharedAccountDisconnect(c *fiber.Ctx) error {
+	u := GetOracleURL(c, v.settings)
+
+	targetURL := u.JoinPath("/v1/vehicle/disconnect/shared")
+	return ProxyRequest(c, targetURL, c.Body(), v.logger)
+}
+
+// SubmitSharedAccountDelete forwards the server-signed delete request to the kaufmann oracle
+// endpoint that burns the vehicle NFT (auto-chaining the disconnect) on behalf of a shared
+// kernel account using the tenant signer. Body: { tokenId }. Response: { jobId }.
+func (v *VehiclesController) SubmitSharedAccountDelete(c *fiber.Ctx) error {
+	u := GetOracleURL(c, v.settings)
+
+	targetURL := u.JoinPath("/v1/vehicle/delete/shared")
+	return ProxyRequest(c, targetURL, c.Body(), v.logger)
+}
+
 func (v *VehiclesController) SubmitCommand(c *fiber.Ctx) error {
 	imei := c.Params("imei", "")
 

--- a/web/src/elements/base-onboarding-element.ts
+++ b/web/src/elements/base-onboarding-element.ts
@@ -692,4 +692,81 @@ export class BaseOnboardingElement extends LitElement {
 
         return { success: true, data: undefined };
     }
+
+    // disconnectSharedAccountVehicle is the server-signed disconnect flow used when the vehicle's
+    // on-chain owner is a shared kernel account that registered our tenant signer. The backend
+    // (POST /vehicle/disconnect/shared) burns the synthetic device itself, so no passkey signature
+    // is required — there is no GET-prepare/sign step. We poll the same per-VIN disconnect status
+    // endpoint the passkey flow uses, since the shared worker lands on the same onboarding status.
+    async disconnectSharedAccountVehicle(tokenId: number, vin: string): Promise<Result<void, string>> {
+        this.dispatchStatusUpdate(msg("Submitting shared-account disconnect..."));
+        const submitResp = await this.api.callApi<VinTransferResponse>(
+            'POST',
+            '/vehicle/disconnect/shared',
+            { tokenId },
+            true,
+        );
+        if (!submitResp.success || !submitResp.data) {
+            return { success: false, error: submitResp.error || "Failed to submit shared-account disconnect" };
+        }
+
+        return this.pollSharedAccountStatus(vin, '/vehicle/disconnect/status', 'Disconnect');
+    }
+
+    // deleteSharedAccountVehicle is the server-signed delete flow for a shared kernel account.
+    // The backend (POST /vehicle/delete/shared) auto-chains the disconnect (burns the synthetic
+    // device first if still live, then the vehicle NFT), so it can be called regardless of the
+    // connection state. No passkey signature is required.
+    async deleteSharedAccountVehicle(tokenId: number, vin: string): Promise<Result<void, string>> {
+        this.dispatchStatusUpdate(msg("Submitting shared-account delete..."));
+        const submitResp = await this.api.callApi<VinTransferResponse>(
+            'POST',
+            '/vehicle/delete/shared',
+            { tokenId },
+            true,
+        );
+        if (!submitResp.success || !submitResp.data) {
+            return { success: false, error: submitResp.error || "Failed to submit shared-account delete" };
+        }
+
+        return this.pollSharedAccountStatus(vin, '/vehicle/delete/status', 'Delete');
+    }
+
+    // pollSharedAccountStatus polls a per-VIN status endpoint until every status reads 'Success'
+    // or the operation times out. Shared disconnect/delete reuse the same status endpoints as the
+    // passkey flow because the shared workers update the same onboarding status.
+    private async pollSharedAccountStatus(vin: string, statusEndpoint: string, label: string): Promise<Result<void, string>> {
+        let success = false;
+        for (const attempt of range(30)) {
+            success = true;
+            const query = qs.stringify({ vins: vin }, { arrayFormat: 'comma' });
+            const status = await this.api.callApi<VinsStatusResult>('GET', `${statusEndpoint}?${query}`, null, true);
+            this.dispatchStatusUpdate(`Checking ${label.toLowerCase()} status... ` + attempt);
+
+            if (!status.success || !status.data) {
+                return { success: false, error: status.error || `Failed to check ${label.toLowerCase()} status` };
+            }
+
+            for (const s of status.data.statuses) {
+                if (s.status !== 'Success') {
+                    success = false;
+                    break;
+                }
+            }
+
+            if (success) {
+                break;
+            }
+
+            if (attempt < 29) {
+                await delay(5000);
+            }
+        }
+
+        if (!success) {
+            return { success: false, error: `${label} operation timed out` };
+        }
+
+        return { success: true, data: undefined };
+    }
 }

--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -97,12 +97,12 @@ export class VehicleListItemElement extends BaseOnboardingElement {
                   </button>
                   <button ?hidden=${!this.canDisconnect(this.item)}
                       type="button"
-                      ?disabled=${this.processing || !this.item.syntheticDevice.tokenId || !this.item.isCurrentUserOwner}
+                      ?disabled=${this.processing || !this.item.syntheticDevice.tokenId || (!this.item.isCurrentUserOwner && !this.isSharedSigner(this.item))}
                       class=${this.connectionProcessing ? 'processing action-btn secondary' : 'action-btn secondary'}
                       @click=${this.disconnectVehicle}
                   >
                       ${msg('disconnect')}
-                      ${!this.item.isCurrentUserOwner ? html`<span class="access-denied-icon-inline">🚫</span>` : ''}
+                      ${(!this.item.isCurrentUserOwner && !this.isSharedSigner(this.item)) ? html`<span class="access-denied-icon-inline">🚫</span>` : ''}
                   </button>
                   <!--
                   <button ?hidden
@@ -197,13 +197,22 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         return [ConnectionStatus.UNKNOWN, ConnectionStatus.DISCONNECTED, ConnectionStatus.CONNECTION_FAILED].includes(this.getConnectionStatus(item));
     }
 
+    // isSharedSigner is true when the connected wallet isn't the owner but our tenant can sign
+    // for the owning kernel account — the server-signed shared-account flow applies.
+    isSharedSigner(item: Vehicle): boolean {
+        return !item.isCurrentUserOwner && !!item.isSharedAccountSigner;
+    }
+
     canDisconnect(item: Vehicle): boolean {
-        if (!item.isCurrentUserOwner) return false;
+        if (!item.isCurrentUserOwner && !this.isSharedSigner(item)) return false;
         return [ConnectionStatus.CONNECTED, ConnectionStatus.DISCONNECTION_FAILED].includes(this.getConnectionStatus(item));
     }
 
     canDelete(item: Vehicle): boolean {
         if (item.tokenId === 0) return false;
+        // Shared-account delete auto-chains the disconnect on the backend, so it may be invoked
+        // regardless of connection state (a still-connected vehicle is disconnected first).
+        if (this.isSharedSigner(item)) return true;
         if (!item.isCurrentUserOwner) return false;
         return [
             ConnectionStatus.UNKNOWN,
@@ -261,7 +270,9 @@ export class VehicleListItemElement extends BaseOnboardingElement {
 
         this.processing = true;
         this.connectionProcessing = true;
-        const result = await this.disconnectVins([this.item.vin]);
+        const result = this.isSharedSigner(this.item)
+            ? await this.disconnectSharedAccountVehicle(this.item.tokenId, this.item.vin)
+            : await this.disconnectVins([this.item.vin]);
         if (result.success) {
             await delay(5000);
             this.processing = false;
@@ -279,13 +290,19 @@ export class VehicleListItemElement extends BaseOnboardingElement {
             return;
         }
 
-        if (!confirm(msg("Are you sure you want to delete the vehicle?"))) {
+        const sharedSigner = this.isSharedSigner(this.item);
+        const deleteConfirm = sharedSigner
+            ? msg("This will disconnect and delete the vehicle. Are you sure?")
+            : msg("Are you sure you want to delete the vehicle?");
+        if (!confirm(deleteConfirm)) {
             return;
         }
 
         this.processing = true;
         this.deletionProcessing = true;
-        const result = await this.deleteVins([this.item.vin]);
+        const result = sharedSigner
+            ? await this.deleteSharedAccountVehicle(this.item.tokenId, this.item.vin)
+            : await this.deleteVins([this.item.vin]);
         if (result.success) {
             await delay(5000);
             this.processing = false;


### PR DESCRIPTION
## Summary

Companion to [kaufmann-oracle#128](https://github.com/DIMO-Network/kaufmann-oracle/pull/128). Adds the proxy passthroughs and UI so a **shared-account signer** can disconnect/delete vehicles they don't own — without a passkey signature (transfer already supported this; disconnect/delete were owner-only).

## Proxy (`api`)

- `SubmitSharedAccountDisconnect` / `SubmitSharedAccountDelete` forward to `POST /v1/vehicle/{disconnect,delete}/shared`, registered in the oracle proxy allowlist.

## Frontend (`web`)

- **`base-onboarding-element.ts`** — `disconnectSharedAccountVehicle` / `deleteSharedAccountVehicle` POST to the `/shared` endpoints (no passkey, no GET-prepare/sign step) and poll the **existing** per-VIN status endpoints via a shared `pollSharedAccountStatus` helper.
- **`vehicle-list-item-element.ts`** — `isSharedSigner` helper; `canDisconnect`/`canDelete` relaxed for shared signers (shared **delete** is allowed even when the vehicle is still connected, because the backend auto-chains the disconnect); dispatch branches to the shared methods; the disconnect button is enabled and the 🚫 hint hidden for shared signers; shared delete uses a "this will disconnect and delete" confirm.

## Test

- `go build ./...` (api) clean.
- `tsc --noEmit` clean; `eslint` 0 errors (pre-existing warnings only).
- Requires the oracle PR to be deployed for the `/shared` endpoints to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)