### PR TITLE
feat(telemetry): live onboarding telemetry panel (frontend)

### DIFF
--- a/web/src/elements/telemetry-modal-element.ts
+++ b/web/src/elements/telemetry-modal-element.ts
@@ -4,6 +4,7 @@ import {customElement, property, state} from "lit/decorators.js";
 import {LitElement} from 'lit';
 import { ApiService } from '../services/api-service';
 import {globalStyles} from "../global-styles.ts";
+import {decodeIo} from "../services/ruptela-io-types.ts";
 import './confirm-modal-element';
 
 interface IoElement {
@@ -88,6 +89,25 @@ export class TelemetryModalElement extends LitElement {
     @state()
     private currentIdentityIndex: number = 0;
 
+    // Live mode: epoch ms of the newest frame received, and a clock tick refreshed each
+    // poll so the "live" indicator re-evaluates without new data.
+    @state()
+    private lastFrameMs: number = 0;
+
+    @state()
+    private nowMs: number = Date.now();
+
+    // Poll the telemetry endpoint while the modal is open so the panel stays current
+    // during a hardware install. Cross-replica safe: reads go through Postgres.
+    private static readonly POLL_INTERVAL_MS = 5000;
+    // Safety stop so a forgotten-open modal doesn't poll forever.
+    private static readonly POLL_MAX_MS = 15 * 60 * 1000;
+    // A frame seen within this window means the device is currently connected.
+    private static readonly LIVE_WINDOW_MS = 40 * 1000;
+
+    private pollTimer: number | null = null;
+    private pollDeadline: number = 0;
+
     private apiService: ApiService;
 
     constructor() {
@@ -97,6 +117,16 @@ export class TelemetryModalElement extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this.stopPolling();
+    }
+
+    // True when a frame was received within the live window (device currently connected).
+    private get isLive(): boolean {
+        return this.lastFrameMs > 0 && (this.nowMs - this.lastFrameMs) < TelemetryModalElement.LIVE_WINDOW_MS;
     }
 
     // Use shadow DOM; styles are provided via globalStyles
@@ -111,7 +141,15 @@ export class TelemetryModalElement extends LitElement {
                 <div class="modal-content telemetry-modal" @click=${(e: Event) => e.stopPropagation()} style="width: 90%; max-width: 90%;">
 
                     <div class="modal-header">
-                        <h3>${msg('Telemetry Data')} - ${this.imei}${this.vin ? ` (${this.vin})` : ''}</h3>
+                        <h3 style="display: flex; align-items: center; gap: 0.6rem;">
+                            <span
+                                title=${this.isLive ? msg('Device connected — receiving data') : msg('No data received recently')}
+                                style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; font-weight: 600; color: ${this.isLive ? '#16a34a' : '#9ca3af'};">
+                                <span style="width: 10px; height: 10px; border-radius: 50%; background-color: ${this.isLive ? '#16a34a' : '#9ca3af'}; ${this.isLive ? 'box-shadow: 0 0 0 3px rgba(22,163,74,0.2);' : ''}"></span>
+                                ${this.isLive ? msg('Live') : msg('Offline')}
+                            </span>
+                            ${msg('Telemetry Data')} - ${this.imei}${this.vin ? ` (${this.vin})` : ''}
+                        </h3>
                         <div style="display: flex; align-items: center; gap: 0.5rem;">
                             <button type="button"
                                     class="btn btn-secondary"
@@ -206,7 +244,7 @@ export class TelemetryModalElement extends LitElement {
                                                 </div>
                                                 <div>
                                                     <div class="tile-label" style="margin-bottom:6px;">${msg('IO Elements')}</div>
-                                                    <pre class="telemetry-blob" style="max-height:30vh; overflow:auto;">${this.formatJsonForDisplay(this.pages[this.currentIndex].io_elements)}</pre>
+                                                    ${this.renderIoElements(this.pages[this.currentIndex].io_elements)}
                                                 </div>
                                             ` : html`
                                                 <div class="no-data">${msg('No telemetry data available')}</div>
@@ -273,9 +311,11 @@ export class TelemetryModalElement extends LitElement {
     }
 
     private closeModal() {
+        this.stopPolling();
         this.show = false;
         this.telemetryData = [];
         this.identityData = [];
+        this.lastFrameMs = 0;
         this.error = "";
         this.loading = false;
         this.resetting = false;
@@ -407,15 +447,26 @@ export class TelemetryModalElement extends LitElement {
         this.sendImmobilizerCommand('off');
     }
 
-    // Method to load telemetry data (to be called from parent)
+    // Method to load telemetry data (to be called from parent). Performs the initial
+    // load with a spinner, then starts the live poll loop.
     public async loadTelemetryData() {
+        await this.applyTelemetry(true);
+        this.startPolling();
+    }
+
+    // applyTelemetry fetches the latest telemetry + identity frames and refreshes the view.
+    // `initial` shows the loading spinner and resets paging; subsequent (poll) refreshes do
+    // neither, so the installer's scroll position and the panel don't flicker.
+    private async applyTelemetry(initial: boolean) {
         if (!this.imei) {
             this.error = msg("No IMEI provided");
             return;
         }
 
-        this.loading = true;
-        this.error = "";
+        if (initial) {
+            this.loading = true;
+            this.error = "";
+        }
 
         try {
             // Fetch both telemetry and identity data in parallel
@@ -433,7 +484,6 @@ export class TelemetryModalElement extends LitElement {
                     this.updateRpmDisplay(first);
                     this.updateIgnitionDisplay(first);
                     this.updateEngineBlockDisplay(first);
-                    this.currentIndex = 0;
                 }
             } else {
                 console.error("Failed to load telemetry data:", telemetryResponse.error);
@@ -442,21 +492,117 @@ export class TelemetryModalElement extends LitElement {
             // Handle identity data
             if (identityResponse.success && identityResponse.data) {
                 this.identityData = Array.isArray(identityResponse.data) ? identityResponse.data : [];
-                this.currentIdentityIndex = 0;
             } else {
                 console.error("Failed to load identity data:", identityResponse.error);
             }
 
-            // Only set error if both failed
-            if (!telemetryResponse.success && !identityResponse.success) {
-                this.error = msg("Failed to load telemetry and identity data");
+            if (initial) {
+                this.currentIndex = 0;
+                this.currentIdentityIndex = 0;
+                // Only surface an error on the initial load; a transient poll failure should
+                // not blow away a working view.
+                if (!telemetryResponse.success && !identityResponse.success) {
+                    this.error = msg("Failed to load telemetry and identity data");
+                }
+            } else {
+                this.clampIndices();
             }
+
+            this.updateLiveness();
         } catch (err) {
-            this.error = msg("Failed to load telemetry data");
+            if (initial) {
+                this.error = msg("Failed to load telemetry data");
+            }
             console.error("Error loading telemetry data:", err);
         } finally {
-            this.loading = false;
+            if (initial) {
+                this.loading = false;
+            }
         }
+    }
+
+    // updateLiveness records the newest frame timestamp (across both feeds) and ticks the
+    // clock so the "Live" indicator re-evaluates on every poll.
+    private updateLiveness() {
+        this.nowMs = Date.now();
+        let latest = 0;
+        for (const arr of [this.telemetryData, this.identityData]) {
+            for (const it of arr) {
+                if (!it.receivedAt) continue;
+                const t = new Date(it.receivedAt).getTime();
+                if (!isNaN(t) && t > latest) latest = t;
+            }
+        }
+        this.lastFrameMs = latest;
+    }
+
+    // Keep the paging indices in range after a refresh changes the number of frames.
+    private clampIndices() {
+        const maxT = this.pages.length - 1;
+        if (this.currentIndex > maxT) this.currentIndex = Math.max(0, maxT);
+        const maxI = this.identityPages.length - 1;
+        if (this.currentIdentityIndex > maxI) this.currentIdentityIndex = Math.max(0, maxI);
+    }
+
+    private startPolling() {
+        this.stopPolling();
+        if (!this.show || !this.imei) return;
+        this.pollDeadline = Date.now() + TelemetryModalElement.POLL_MAX_MS;
+        this.pollTimer = window.setInterval(() => {
+            if (!this.show || Date.now() > this.pollDeadline) {
+                this.stopPolling();
+                return;
+            }
+            void this.applyTelemetry(false);
+        }, TelemetryModalElement.POLL_INTERVAL_MS);
+    }
+
+    private stopPolling() {
+        if (this.pollTimer !== null) {
+            window.clearInterval(this.pollTimer);
+            this.pollTimer = null;
+        }
+    }
+
+    // Decode a record's IO elements (hex values) into a typed, human-readable table.
+    private renderIoElements(ioElements: unknown) {
+        if (!Array.isArray(ioElements) || ioElements.length === 0) {
+            return html`<pre class="telemetry-blob" style="max-height:30vh; overflow:auto;">${this.formatJsonForDisplay(ioElements)}</pre>`;
+        }
+        const rows = ioElements
+            .filter((el: any) => el && typeof el === 'object' && 'id' in el)
+            .map((el: any) => {
+                const decoded = decodeIo(Number(el.id), typeof el.value === 'string' ? el.value : '');
+                return {id: Number(el.id), ...decoded};
+            });
+        return html`
+            <div style="max-height:30vh; overflow:auto;">
+                <table style="width:100%; border-collapse:collapse; font-size:0.8rem;">
+                    <thead>
+                        <tr style="text-align:left; border-bottom:1px solid #e5e7eb;">
+                            <th style="padding:2px 6px;">${msg('IO')}</th>
+                            <th style="padding:2px 6px;">${msg('Type')}</th>
+                            <th style="padding:2px 6px;">${msg('Value')}</th>
+                            <th style="padding:2px 6px;">${msg('Hex')}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${rows.map(r => html`
+                            <tr style="border-bottom:1px solid #f3f4f6;">
+                                <td style="padding:2px 6px; font-variant-numeric: tabular-nums;">${r.id}</td>
+                                <td style="padding:2px 6px; opacity:0.7;">${r.type}</td>
+                                <td style="padding:2px 6px; font-weight:600; font-variant-numeric: tabular-nums;">${r.display}</td>
+                                <td style="padding:2px 6px; opacity:0.6;"><code>${r.hex}</code></td>
+                            </tr>
+                        `)}
+                    </tbody>
+                </table>
+            </div>
+            <details style="margin-top:6px;">
+                <summary style="cursor:pointer; font-size:0.75rem; opacity:0.7;">${msg('Raw')}</summary>
+                <pre class="telemetry-blob" style="max-height:30vh; overflow:auto;">${this.formatJsonForDisplay(ioElements)}</pre>
+            </details>
+        `;
     }
 
     private getRawTelemetryRows(item: TelemetryData): { header: unknown; io_elements: unknown }[] {

--- a/web/src/services/ruptela-io-types.ts
+++ b/web/src/services/ruptela-io-types.ts
@@ -1,0 +1,147 @@
+// Ruptela IO value decoding, ported from the kaufmann-oracle backend
+// (internal/ruptela/io_types.go). The device sends IO element values as raw bytes;
+// the oracle serializes them as a hex string. Most values are unsigned big-endian
+// integers, but a number of IO IDs are signed, ASCII strings, bitmaps, hex blobs, or
+// Unix timestamps. Keep this map in sync with io_types.go if the backend list changes.
+
+export type IoType =
+    | 'unsigned'
+    | 'signed'
+    | 'string'
+    | 'bitmap'
+    | 'header'
+    | 'hex'
+    | 'timestamp';
+
+// IDs that are NOT the default unsigned integer. Grouped to mirror io_types.go.
+const SIGNED_IDS = [
+    // 1-byte signed
+    6, 32, 49, 50, 51, 56, 57, 58, 59, 60, 61, 62, 63, 64, 75, 76, 96, 97, 101, 103,
+    115, 144, 145, 146, 147, 148, 149, 184, 185, 186, 187, 212, 419, 509, 510, 511,
+    512, 513, 514, 584, 585, 586, 587, 594, 600, 601, 602, 603, 604, 611, 612, 613,
+    639, 727, 733, 734, 755, 756, 757, 842, 843, 844, 1000, 1172, 1173, 1174, 1175, 1176,
+    // 2-byte signed
+    26, 33, 74, 78, 79, 80, 402, 403, 404, 520, 564, 732, 916, 917, 927,
+];
+
+const STRING_IDS = [
+    34, 70, 71, 72, 73, 104, 105, 106, 123, 124, 125, 126, 127, 128, 129, 152, 153, 154,
+    155, 156, 157, 158, 167, 168, 171, 172, 536, 575, 581, 582, 614, 615, 616, 617, 620,
+    621, 622, 623, 624, 625, 633, 634, 635, 636, 646, 647, 648, 649, 760, 761, 823, 824,
+    825, 939, 940, 941, 981, 982, 983, 984, 1144, 1145,
+];
+
+const BITMAP_IDS = [
+    40, 93, 151, 138, 142, 352, 353, 354, 398, 399, 400, 401, 500, 501, 502, 503, 504,
+    505, 506, 518, 523, 561, 562, 568, 569, 570, 573, 574, 588, 589, 590, 591, 592, 593,
+    626, 650, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 850, 870, 871,
+    872, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 931, 933, 951, 1153, 1186,
+];
+
+const HEADER_IDS = [7, 8, 9, 1177];
+
+const HEX_IDS = [
+    1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1209, 1210, 1211, 1212, 1213, 1214,
+    1215, 1216, 1217, 1218, 1219, 1220, 5011,
+];
+
+const TIMESTAMP_IDS = [715, 531, 532];
+
+const IO_TYPE_MAP: Map<number, IoType> = (() => {
+    const m = new Map<number, IoType>();
+    const add = (ids: number[], t: IoType) => ids.forEach(id => m.set(id, t));
+    add(SIGNED_IDS, 'signed');
+    add(STRING_IDS, 'string');
+    add(BITMAP_IDS, 'bitmap');
+    add(HEADER_IDS, 'header');
+    add(HEX_IDS, 'hex');
+    add(TIMESTAMP_IDS, 'timestamp');
+    return m;
+})();
+
+export function getIoType(id: number): IoType {
+    return IO_TYPE_MAP.get(id) ?? 'unsigned';
+}
+
+function hexToBytes(hex: string): number[] {
+    let h = hex.trim();
+    if (h.startsWith('0x') || h.startsWith('0X')) h = h.slice(2);
+    if (h.length % 2 !== 0) h = '0' + h;
+    if (h.length === 0 || !/^[0-9a-fA-F]+$/.test(h)) return [];
+    const bytes: number[] = [];
+    for (let i = 0; i < h.length; i += 2) {
+        bytes.push(parseInt(h.slice(i, i + 2), 16));
+    }
+    return bytes;
+}
+
+function toUpperHex(bytes: number[]): string {
+    return bytes.map(b => b.toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+// Big-endian unsigned. BigInt keeps 8-byte values exact.
+function decodeUnsigned(bytes: number[]): bigint {
+    let v = 0n;
+    for (const b of bytes) v = (v << 8n) | BigInt(b);
+    return v;
+}
+
+// Big-endian two's-complement signed, sized to the byte length.
+function decodeSigned(bytes: number[]): bigint {
+    const u = decodeUnsigned(bytes);
+    const bits = BigInt(bytes.length * 8);
+    const signBit = 1n << (bits - 1n);
+    return u & signBit ? u - (1n << bits) : u;
+}
+
+// ASCII string, truncated at the first null byte (matches backend parseStringValue).
+function decodeString(bytes: number[]): string {
+    const out: number[] = [];
+    for (const b of bytes) {
+        if (b === 0) break;
+        out.push(b);
+    }
+    return out.map(c => String.fromCharCode(c)).join('');
+}
+
+export interface DecodedIo {
+    type: IoType;
+    // Human-readable decoded value for display.
+    display: string;
+    // Uppercase hex of the raw bytes, always available for reference.
+    hex: string;
+}
+
+// decodeIo interprets a hex-encoded IO value according to its IO id's type.
+export function decodeIo(id: number, hexValue: string): DecodedIo {
+    const bytes = hexToBytes(hexValue);
+    const hex = toUpperHex(bytes);
+    const type = getIoType(id);
+
+    if (bytes.length === 0) {
+        return { type, display: '—', hex };
+    }
+
+    switch (type) {
+        case 'signed':
+            return { type, display: decodeSigned(bytes).toString(), hex };
+        case 'string': {
+            const s = decodeString(bytes);
+            return { type, display: s.length > 0 ? s : '—', hex };
+        }
+        case 'bitmap':
+        case 'hex':
+            return { type, display: `0x${hex}`, hex };
+        case 'header':
+            return { type, display: '—', hex };
+        case 'timestamp': {
+            const secs = Number(decodeUnsigned(bytes));
+            const d = new Date(secs * 1000);
+            const display = isNaN(d.getTime()) ? String(secs) : `${d.toLocaleString()} (${secs})`;
+            return { type, display, hex };
+        }
+        case 'unsigned':
+        default:
+            return { type, display: decodeUnsigned(bytes).toString(), hex };
+    }
+}


### PR DESCRIPTION
## Why
The onboarding view's per-vehicle telemetry modal showed a frozen snapshot. Hardware installers need it **live** while debugging a device, plus an at-a-glance "is the device connected" signal and readable IO values.

Pairs with the oracle backend change: DIMO-Network/kaufmann-oracle#132.

## Changes
- **5s polling while the modal is open** against the existing `/pending-vehicle-telemetry` endpoint (15-min safety stop). Poll refreshes are silent — no loading spinner, paging position preserved (indices clamped). Polling stops on close and on `disconnectedCallback`. Follows the existing `reports.ts` polling pattern.
- **"Live" header indicator:** a dot + label that defaults gray ("Offline") and turns green ("Live") when a frame arrived within the last 40s — re-evaluated every poll, so it also reverts to gray when data goes stale.
- **Decoded IO values:** the IO Elements panel now renders a typed table (`IO | Type | Value | Hex`) instead of raw hex JSON, porting the signed/unsigned/string/bitmap/hex/timestamp type map from the oracle's `internal/ruptela/io_types.go` (`web/src/services/ruptela-io-types.ts`). Raw JSON stays available under a collapsible `<details>`.

## Why polling, not WebSockets
Frames flow device → gnet TCP → Postgres, and the browser reads via the proxy → REST → (any replica) → Postgres. Postgres is the shared bus, so polling is cross-replica safe (the device may be sticky to a different replica than the browser) **with no proxy or ingress changes.** The existing `pending-vehicle-telemetry` route is already proxied (`api/internal/app/app.go:98`), so **no b2b proxy changes were needed.**

## Verification
- `tsc --noEmit` clean, `npm run build` succeeds, `eslint` 0 errors (warnings match existing file conventions).
- Backend dependency (status-gated rolling-window capture + mint cleanup) is in kaufmann-oracle#132; without it, stored frames still latch at 10 and live updates won't flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)