### PR TITLE
chore(dependabot): ignore noisy/unfixable update churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+# This config exists primarily to apply `ignore` rules to Dependabot SECURITY updates
+# (those run from repo settings, not from this file). `open-pull-requests-limit: 0` keeps
+# version-update PR noise off while leaving security updates active and honoring the
+# ignores below — quieting the low-value/unfixable churn without changing how patches land.
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      # Vite 7/8 switched to the rolldown bundler, whose linux native binding fails to load
+      # in our Docker build (broke every build; see PR #147). Stay on v6 here and upgrade
+      # deliberately (raise Docker Node, verify rolldown on linux) rather than via a bump.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite-plugin-static-copy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-basic-ssl"
+        update-types: ["version-update:semver-major"]
+      # Transitive, dev/build-only advisories with no resolvable fix path — they only
+      # produce failing Dependabot runs, not actionable updates. esbuild is included because
+      # its advisory is what drove the breaking Vite 8 bump; the issue is the dev server
+      # only and does not affect production builds.
+      - dependency-name: "esbuild"
+      - dependency-name: "uuid"
+      - dependency-name: "undici"
+      - dependency-name: "tmp"
+      - dependency-name: "ws"
+      - dependency-name: "serialize-javascript"


### PR DESCRIPTION
Follow-up to #147. Adds the first `.github/dependabot.yml`.

## What it does
There was no `dependabot.yml`, so only Dependabot **security** updates were running (from repo settings) — and several keep **failing**: transitive advisories with no resolvable fix path (uuid, undici, tmp, ws, serialize-javascript), plus the esbuild advisory that drove the breaking Vite 8 bump.

This config:
- **`open-pull-requests-limit: 0`** — does **not** introduce new version-update PR noise. It exists so the `ignore` rules below apply to the still-active **security** updates.
- **Ignores Vite-toolchain major bumps** (`vite`, `vite-plugin-static-copy`, `@vitejs/plugin-basic-ssl`) so the rolldown/Vite 8 break that downed every build (#147) can't recur via an auto bump. A real Vite 7/8 upgrade should be deliberate (raise Docker Node, verify rolldown's linux binding).
- **Ignores transitive dev/build-only advisories with no fix path** (`esbuild`, `uuid`, `undici`, `tmp`, `ws`, `serialize-javascript`) that only generate failing Dependabot runs. The esbuild advisory affects the dev server only, not production builds.

## Effect
- The recurring red "Dependabot Updates" jobs for these deps go quiet.
- Vite stays on v6 until upgraded intentionally.
- Patch/minor **security** updates for everything else still flow normally.

Tune the ignore list anytime — e.g. drop an entry once an upstream fix path opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)