### PR TITLE
feat(emails): resolve delivery status on demand per row

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -191,6 +191,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 
 	// emails (Kaufmann-only on the oracle side)
 	oracleApp.Get("/emails", genericProxyCtrl.Proxy)
+	oracleApp.Get("/emails/:messageId/events", genericProxyCtrl.Proxy)
 
 	// settings the app needs to operate, pulled from config / env vars
 	oracleApp.Get("/settings", settingsCtrl.GetSettings) // todo some of these are oracle specific

--- a/web/src/views/emails.ts
+++ b/web/src/views/emails.ts
@@ -22,6 +22,13 @@ interface EmailsResponse {
     next: string;
 }
 
+interface EmailEventsResponse {
+    deliveredAt?: number;
+    openedAt?: number;
+    bouncedAt?: number;
+    status: string;
+}
+
 @customElement("emails-view")
 export class EmailsView extends LitElement {
     static styles = [
@@ -51,6 +58,10 @@ export class EmailsView extends LitElement {
     @state() private nextCursor = "";
     @state() private cursorStack: string[] = [];
     @state() private pageSize = 50;
+    // Delivery ids currently being resolved on demand, and those already resolved
+    // (so we stop offering the button even when no delivery/open event came back).
+    @state() private resolving: Set<string> = new Set();
+    @state() private resolved: Set<string> = new Set();
 
     async connectedCallback() {
         super.connectedCallback();
@@ -60,6 +71,9 @@ export class EmailsView extends LitElement {
     private async fetchEmails(cursor: string) {
         this.loading = true;
         this.errorMessage = "";
+        // Each page is a fresh set of rows; drop any per-row resolve state.
+        this.resolving = new Set();
+        this.resolved = new Set();
         try {
             const params = new URLSearchParams({ limit: String(this.pageSize) });
             if (cursor) params.set("next", cursor);
@@ -117,6 +131,39 @@ export class EmailsView extends LitElement {
         return d.toLocaleString();
     }
 
+    // resolveEvents fetches a single message's delivery lifecycle on demand and fills
+    // delivered/opened/bounced + status into that row. The listing itself stays one cheap
+    // call; the provider (Postmark) resolves per-message details only when asked.
+    private async resolveEvents(m: EmailMessage) {
+        if (!m.deliveryId || this.resolving.has(m.deliveryId)) return;
+        this.resolving = new Set(this.resolving).add(m.deliveryId);
+        try {
+            const result = await ApiService.getInstance().callApi<EmailEventsResponse>(
+                "GET",
+                `/emails/${encodeURIComponent(m.deliveryId)}/events`,
+                null,
+                true,
+                true
+            );
+            if (result.success && result.data) {
+                m.deliveredAt = result.data.deliveredAt;
+                m.openedAt = result.data.openedAt;
+                m.bouncedAt = result.data.bouncedAt;
+                if (result.data.status) m.status = result.data.status;
+                this.emails = [...this.emails]; // trigger re-render with the mutated row
+            }
+        } catch (e) {
+            // Non-fatal: leave the row as-is and let the user retry via Refresh.
+            // eslint-disable-next-line no-console
+            console.error("Failed to resolve email events:", e);
+        } finally {
+            const next = new Set(this.resolving);
+            next.delete(m.deliveryId);
+            this.resolving = next;
+            this.resolved = new Set(this.resolved).add(m.deliveryId);
+        }
+    }
+
     render() {
         return html`
             <div
@@ -165,7 +212,20 @@ export class EmailsView extends LitElement {
                                                                 ${m.status}
                                                             </span>
                                                         </td>
-                                                        <td>${this.formatTimestamp(m.deliveredAt)}</td>
+                                                        <td>
+                                                            ${m.deliveredAt
+                                                                ? this.formatTimestamp(m.deliveredAt)
+                                                                : this.resolving.has(m.deliveryId)
+                                                                    ? html`<span style="opacity:0.6;">${msg("Resolving...")}</span>`
+                                                                    : this.resolved.has(m.deliveryId)
+                                                                        ? "-"
+                                                                        : html`<button
+                                                                              class="btn btn-sm"
+                                                                              @click=${() => this.resolveEvents(m)}
+                                                                          >
+                                                                              ${msg("Resolve")}
+                                                                          </button>`}
+                                                        </td>
                                                         <td>${this.formatTimestamp(m.openedAt)}</td>
                                                         <td style="font-family: monospace; font-size: 12px;">
                                                             ${m.deliveryId}


### PR DESCRIPTION
## What

Frontend companion to the Postmark email migration (kaufmann-oracle #137). Postmark's outbound listing returns **status + sent time only** — delivered/opened timestamps come from a separate per-message detail call. To keep the listing a single cheap request (no N+1), the **Emails** view now resolves a row's delivery lifecycle **on demand**.

## Changes

- **`api/internal/app/app.go`** — proxy `GET /emails/:messageId/events` to the oracle's new events endpoint (Kaufmann-gated server-side).
- **`web/src/views/emails.ts`** — keep the Delivered/Opened columns; when a row has no Delivered timestamp, show a **Resolve** button that fetches `/emails/:messageId/events` and fills delivered/opened/bounced + status into that row. Per-row `resolving`/`resolved` state, cleared on page change. Failures are non-fatal (retry via Refresh). Under Customer.io, rows that already carry metrics render the timestamp and never show the button.

## Notes

- No behavior change until the backend runs with `EMAIL_PROVIDER=postmark`; the route and button are harmless under Customer.io.
- Depends on kaufmann-oracle #137 being deployed for the events endpoint to exist.

## Validation

- `go build ./...` (api), `tsc --noEmit`, and `eslint` on the changed view all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB7J57j6xNXMQP5gLXj3hr