### PR TITLE
Support transferring vehicles to existing accounts by email

### DIFF
--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -122,7 +122,27 @@ export class TransferModalElement extends BaseOnboardingElement {
     @state()
     private accountFound: boolean = false;
 
+    // Email-lookup state (mirrors the wallet lookup). Populated by the debounced
+    // lookupEmailAccount so we can transfer to an existing account directly instead of always
+    // creating a new one.
+    @state()
+    private isCheckingEmail = false;
+
+    @state()
+    private emailAccountFound = false; // existing account; resolvedEmailWallet is set
+
+    @state()
+    private emailAccountNew = false; // 404 from lookup: no account yet, will create one
+
+    @state()
+    private emailLookupError = ""; // lookup unavailable/blocked (e.g. non-allowlisted tenant)
+
+    @state()
+    private resolvedEmailWallet = "";
+
     private accountCheckTimeout?: number;
+
+    private emailCheckTimeout?: number;
 
     constructor() {
         super();
@@ -212,24 +232,41 @@ export class TransferModalElement extends BaseOnboardingElement {
                                 </div>
                                 
                                 <div class="transfer-option">
-                                    <h4>${msg('Transfer by Email (new accounts)')}</h4>
+                                    <h4>${msg('Transfer by Email')}</h4>
                                     <form class="transfer-form">
                                         <label>
                                             ${msg('Email Address')}
-                                            <input type="email" 
-                                                   placeholder="user@example.com"
-                                                   .value=${this.email}
-                                                   @input=${this.handleEmailInput}>
+                                            <div style="display: flex; align-items: center; gap: 8px;">
+                                                <input type="email"
+                                                       placeholder="user@example.com"
+                                                       style="flex: 1; min-width: 0;"
+                                                       .value=${this.email}
+                                                       @input=${this.handleEmailInput}>
+                                                ${this.isCheckingEmail ? html`<span style="font-size: 12px; color: #666; flex: 0 0 auto;">${msg('Checking...')}</span>` : nothing}
+                                                ${this.emailAccountFound ? html`<span style="color: #22c55e; font-size: 16px; flex: 0 0 auto;">✓</span>` : nothing}
+                                            </div>
                                         </label>
-                                        <button type="button" 
-                                                class="action-btn ${this.processing ? 'processing' : ''}" 
+                                        ${this.emailAccountFound ? html`
+                                            <div style="font-size: 12px; color: #16a34a; margin-top: 6px;">
+                                                ${msg('An existing account was found. The vehicle will be transferred directly to their wallet.')}
+                                            </div>
+                                        ` : nothing}
+                                        ${this.emailAccountNew ? html`
+                                            <div style="font-size: 12px; color: #666; margin-top: 6px;">
+                                                ${msg('No account exists for this email yet. The user will receive an email with an OTP code to log in and claim the vehicle.')}
+                                            </div>
+                                        ` : nothing}
+                                        ${this.emailLookupError ? html`
+                                            <div style="font-size: 12px; color: #fc0303; margin-top: 6px;">
+                                                ${this.emailLookupError}
+                                            </div>
+                                        ` : nothing}
+                                        <button type="button"
+                                                class="action-btn ${this.processing ? 'processing' : ''}"
                                                 @click=${() => this.confirmTransfer('email')}
-                                                ?disabled=${!this.email.trim() || this.processing}>
+                                                ?disabled=${!this.email.trim() || this.processing || this.isCheckingEmail || !!this.emailLookupError}>
                                             ${this.processing ? msg('Processing...') : msg('Transfer by Email')}
                                         </button>
-                                        <p>
-                                           ${msg('User will receive an email with an OTP code to login to the App. This will not work for existing accounts.')}
-                                        </p>
                                     </form>
                                 </div>
                             </div>
@@ -250,6 +287,14 @@ export class TransferModalElement extends BaseOnboardingElement {
         this.email = "";
         this.errorMessage = "";
         this.statusMessage = "";
+        this.isCheckingEmail = false;
+        this.emailAccountFound = false;
+        this.emailAccountNew = false;
+        this.emailLookupError = "";
+        this.resolvedEmailWallet = "";
+        if (this.emailCheckTimeout) {
+            clearTimeout(this.emailCheckTimeout);
+        }
         console.log("Closing transfer modal");
         
         // Dispatch event to parent
@@ -260,8 +305,59 @@ export class TransferModalElement extends BaseOnboardingElement {
     }
 
     private handleEmailInput = (e: InputEvent) => {
-        this.email = (e.target as HTMLInputElement).value;
+        const value = (e.target as HTMLInputElement).value;
+        this.email = value;
+        this.emailAccountFound = false;
+        this.emailAccountNew = false;
+        this.emailLookupError = "";
+        this.resolvedEmailWallet = "";
+
+        if (this.emailCheckTimeout) {
+            clearTimeout(this.emailCheckTimeout);
+        }
+
+        const trimmed = value.trim();
+        if (!trimmed || !this.isLikelyEmail(trimmed)) {
+            this.isCheckingEmail = false;
+            return;
+        }
+
+        this.isCheckingEmail = true;
+        this.emailCheckTimeout = window.setTimeout(() => {
+            this.lookupEmailAccount(trimmed);
+        }, 400);
     };
+
+    private isLikelyEmail(value: string): boolean {
+        return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value);
+    }
+
+    // Resolve an account by email. An existing account returns a walletAddress (the Accounts
+    // service only echoes it to our allowlisted developer JWT); a 404 means no account yet, so
+    // we'll create one on submit; anything else means the lookup is unavailable for this tenant.
+    private async lookupEmailAccount(email: string) {
+        this.isCheckingEmail = true;
+        const query = `?email=${encodeURIComponent(email)}`;
+        // Backend GET /account requires Tenant-Id (matches the wallet lookup + POST create path).
+        const resp = await this.api.callApi<AccountData>('GET', `/account${query}`, null, true, true, true);
+
+        if (resp.success && resp.data?.walletAddress) {
+            this.emailAccountFound = true;
+            this.resolvedEmailWallet = resp.data.walletAddress;
+            this.emailAccountNew = false;
+            this.emailLookupError = "";
+        } else if (resp.status === 404) {
+            this.emailAccountNew = true;
+            this.emailAccountFound = false;
+            this.emailLookupError = "";
+        } else {
+            // 401/5xx, or a 200 with no walletAddress (non-allowlisted tenant): can't resolve.
+            this.emailAccountFound = false;
+            this.emailAccountNew = false;
+            this.emailLookupError = msg("Account lookup isn't available for this tenant. Please transfer by wallet address instead.");
+        }
+        this.isCheckingEmail = false;
+    }
 
     private handleWalletInput = (e: InputEvent) => {
         const value = (e.target as HTMLInputElement).value;
@@ -312,16 +408,31 @@ export class TransferModalElement extends BaseOnboardingElement {
         this.statusMessage = msg("Processing transfer for IMEI: ") + this.imei;
         
         if (transferType === 'email') {
-            this.statusMessage = msg("Creating account for email: ") + this.email;
-            const createAccountResp = await this.createAccount(this.email);
-            if (!createAccountResp.success) {
-                this.errorMessage = createAccountResp.error;
+            if (this.emailLookupError) {
+                this.errorMessage = this.emailLookupError;
                 this.processing = false;
                 return;
             }
-            this.walletAddress = createAccountResp.data.walletAddress;
-            console.log("Created account with wallet address:", this.walletAddress);
-            this.statusMessage = msg("Account created with wallet address: ") + this.walletAddress;
+
+            if (this.emailAccountFound && this.resolvedEmailWallet) {
+                // Existing account: transfer straight to the resolved wallet — no account
+                // creation, no OTP email.
+                this.walletAddress = this.resolvedEmailWallet;
+                console.log("Transferring to existing account wallet:", this.walletAddress);
+                this.statusMessage = msg("Transferring to existing account: ") + this.walletAddress;
+            } else {
+                // New account: create it (user gets an OTP email) then transfer.
+                this.statusMessage = msg("Creating account for email: ") + this.email;
+                const createAccountResp = await this.createAccount(this.email);
+                if (!createAccountResp.success) {
+                    this.errorMessage = createAccountResp.error;
+                    this.processing = false;
+                    return;
+                }
+                this.walletAddress = createAccountResp.data.walletAddress;
+                console.log("Created account with wallet address:", this.walletAddress);
+                this.statusMessage = msg("Account created with wallet address: ") + this.walletAddress;
+            }
         }
 
         if (this.walletAddress == "") {

--- a/web/src/generated/locales/es.ts
+++ b/web/src/generated/locales/es.ts
@@ -5,8 +5,8 @@
     import {html} from 'lit';
     import {str} from '@lit/localize';
 
-    /* eslint-disable no-irregular-whitespace */
-    /* eslint-disable @typescript-eslint/no-explicit-any */
+     
+     
 
     export const templates = {
       'h104d0372d43faa07': html`Para conectar su flota necesitará una cuenta de desarrollador DIMO. Si aún no tiene una, cree una en <a href="https://console.dimo.org" target="_blank">console.dimo.org</a>.`,
@@ -174,6 +174,7 @@
 's479350a32274d64c': `Plantillas de Reporte`,
 's47d2a0ab45bec70a': `Fecha de Fin`,
 's47f4637aaa012055': `Grupos de Flota`,
+'s4821c2e8d60cdfeb': `Se encontró una cuenta existente. El vehículo se transferirá directamente a su wallet.`,
 's484c770275ea96db': `Error al registrar al menos un VIN`,
 's49534419cd9c812a': `Hex`,
 's49730f3d5751a433': `Cargando...`,
@@ -187,6 +188,7 @@
 's4bdf85b3b7899924': `Usuarios Administradores`,
 's4bea2bd4fd7c752a': `¿Está seguro de que desea continuar?`,
 's4cb3d569372cf980': `Confirmar Registro`,
+'s4de430b40c94e903': `Resolver`,
 's4e035c2ccf0535fd': `Error al cargar datos del vehículo`,
 's4e2391300b797f3c': `VER PERFIL DE USUARIO →`,
 's4ee6d90c2eb5ecdc': `Nombre del Inquilino`,
@@ -239,6 +241,7 @@
 's64f1b498f33d3ec6': `Ingrese el nombre del inquilino`,
 's65480c812ea72845': `Revise y opcionalmente actualice las definiciones de vehículos antes del registro:`,
 's659773b2545b1d37': `El aumento del nivel de combustible por encima de este % es un evento de recarga`,
+'s6657ec390e642b35': `Aún no existe una cuenta para este correo. El usuario recibirá un correo con un código OTP para iniciar sesión y reclamar el vehículo.`,
 's666854dc11c7d9aa': `Cargando usuarios administradores...`,
 's6686fcc6d2c8f0bd': `Nota`,
 's6694b6896680ffb2': `Resumen de Flota`,
@@ -259,7 +262,6 @@
 's6b28de40b64d4995': `Usar OTP`,
 's6b2beba7ab637e9e': `Roles`,
 's6b37d154cadc74f3': `Seleccione una plantilla de reporte, elija grupos de flota y haga clic en EJECUTAR REPORTE`,
-'s6b6aa40896f2f508': `Transferir por Correo (cuentas nuevas)`,
 's6d3efe9c3d836a5f': `Cargando permisos...`,
 's6e196b93c62518bb': `Se encuentra en su consola de desarrollador DIMO.`,
 's6e21b7074a7aa5ea': `¿Está seguro de que desea eliminar el vehículo?`,
@@ -269,6 +271,7 @@
 's71176fa2fc28ff49': `Compartir vehículos con Desarrollador`,
 's74185329ba1871db': `Marca Modelo Año`,
 's744a500def5015c5': `CAN / Instantánea de Telemetría`,
+'s74680840bad16cf8': `La búsqueda de cuentas no está disponible para este inquilino. Por favor, transfiera usando la dirección de wallet.`,
 's74b31022385d5341': `Por favor reclame sus IMEIs cada vez que compre o agregue un nuevo dispositivo a su flota`,
 's74b85ca082cba3d6': `No se encontraron vehículos compartidos.`,
 's75d83fc3f0cfab40': `Encabezado`,
@@ -300,7 +303,6 @@
 's8405cb72d831fbb4': `Error al Forzar Eliminación`,
 's843885ab933dbeb4': `Buscar usuarios administradores...`,
 's84399fda8df166f8': `Confirmar Registro de Vehículos`,
-'s843bb7ff5e8fe2da': `El usuario recibirá un correo con un código OTP para iniciar sesión en la App. Esto no funcionará para cuentas existentes.`,
 's8492be16503be576': `Definición (requerida):`,
 's853062af0bcf2d88': `Tipo de ID Gubernamental`,
 's85b3fc77a7f5c9e4': `Cargando datos del usuario...`,
@@ -410,6 +412,7 @@
 'sb6fa8ad2ae025529': `Compartir Seguimiento`,
 'sb78a66c8b3d23215': `Verificando...`,
 'sb79b345ef0ba51ef': `Cargando usuarios...`,
+'sb7d62e5ad10d8e7b': `Transfiriendo a cuenta existente: `,
 'sb7efe2955d7a41f8': `Registro`,
 'sb8054673c62ea9ed': `Vehículos Propios`,
 'sb819464683a062e5': `Clic para actualizar estado de inventario`,
@@ -430,6 +433,7 @@
 'sc2c6ab213f763d92': `Información del Perfil`,
 'sc30957ee63a1f7de': `Es Administrador`,
 'sc4d6d7415e991063': `Formato de color inválido. Por favor use formato hexadecimal (ej., #FF5733)`,
+'sc513edd6534cd35a': `Resolviendo...`,
 'sc592307ea80f16b9': `Desconocido`,
 'sc7641c9aab0c2232': `El nombre del grupo es requerido`,
 'scab045cc56e0e078': `Dispositivos existentes sin acuñar`,

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -830,10 +830,6 @@
   <source>OR</source>
   <target>O</target>
 </trans-unit>
-<trans-unit id="s6b6aa40896f2f508">
-  <source>Transfer by Email (new accounts)</source>
-  <target>Transferir por Correo (cuentas nuevas)</target>
-</trans-unit>
 <trans-unit id="s1e2e135dac5ba993">
   <source>Email Address</source>
   <target>Dirección de Correo</target>
@@ -841,10 +837,6 @@
 <trans-unit id="s75e98404c877a843">
   <source>Transfer by Email</source>
   <target>Transferir por Correo</target>
-</trans-unit>
-<trans-unit id="s843bb7ff5e8fe2da">
-  <source>User will receive an email with an OTP code to login to the App. This will not work for existing accounts.</source>
-  <target>El usuario recibirá un correo con un código OTP para iniciar sesión en la App. Esto no funcionará para cuentas existentes.</target>
 </trans-unit>
 <trans-unit id="sfa1eef635795b63c">
   <source>Processing transfer for IMEI: </source>
@@ -2588,6 +2580,30 @@
 <trans-unit id="s537534ff0214c8a6">
   <source>Refreshing…</source>
   <target>Actualizando…</target>
+</trans-unit>
+<trans-unit id="s4821c2e8d60cdfeb">
+  <source>An existing account was found. The vehicle will be transferred directly to their wallet.</source>
+  <target>Se encontró una cuenta existente. El vehículo se transferirá directamente a su wallet.</target>
+</trans-unit>
+<trans-unit id="s6657ec390e642b35">
+  <source>No account exists for this email yet. The user will receive an email with an OTP code to log in and claim the vehicle.</source>
+  <target>Aún no existe una cuenta para este correo. El usuario recibirá un correo con un código OTP para iniciar sesión y reclamar el vehículo.</target>
+</trans-unit>
+<trans-unit id="s74680840bad16cf8">
+  <source>Account lookup isn't available for this tenant. Please transfer by wallet address instead.</source>
+  <target>La búsqueda de cuentas no está disponible para este inquilino. Por favor, transfiera usando la dirección de wallet.</target>
+</trans-unit>
+<trans-unit id="sb7d62e5ad10d8e7b">
+  <source>Transferring to existing account: </source>
+  <target>Transfiriendo a cuenta existente: </target>
+</trans-unit>
+<trans-unit id="sc513edd6534cd35a">
+  <source>Resolving...</source>
+  <target>Resolviendo...</target>
+</trans-unit>
+<trans-unit id="s4de430b40c94e903">
+  <source>Resolve</source>
+  <target>Resolver</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
## What & why

The Transfer Vehicle modal's email path previously **always** created a new account (OTP flow) and warned it wouldn't work for existing accounts. It now resolves the account by email first — via the updated `GET /account` lookup that returns `walletAddress` for our allowlisted developer client — and transfers **directly** to an existing account, only falling back to account creation when none exists.

## Changes

- **Debounced live lookup** on the email field (mirrors the wallet field):
  - Existing account (200 + `walletAddress`) → ✓ confirmation, transfers directly (no account creation, no OTP email).
  - New account (404) → OTP-creation notice, then the existing create-account flow.
  - Lookup unavailable (401/5xx, or non-allowlisted tenant) → error, submit disabled.
- `confirmTransfer('email')` transfers straight to the resolved wallet for an existing account; otherwise creates the account as before.
- Copy updated (dropped "(new accounts)" and the "won't work for existing accounts" note) + Spanish translations for the new strings (also filled two pre-existing untranslated strings surfaced by re-extraction).

## Depends on

DIMO-Network/kaufmann-oracle#140 — the oracle must send the developer JWT on email lookups for `walletAddress` to come back. Until that ships, email lookups resolve to the "lookup unavailable" path.

## Test

- `npm run build` (tsc + vite) clean; `npm run lint` 0 errors; localize extract/build regenerated `es.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)