### PR TITLE
feat: Billable Vehicles dashboard tile and Dealer Inventory / Standby state

### DIFF
--- a/web/src/elements/add-vin-element.ts
+++ b/web/src/elements/add-vin-element.ts
@@ -112,7 +112,6 @@ export class AddVinElement extends BaseOnboardingElement {
     @state() private selectedImeis: string[] = [];
     @state() private selectedPendingVehicles: string[] = [];
     @state() private selectedVinsForSubmission: string[] = [];
-    @state() private vinToImeiMap: Map<string, string> = new Map();
 
 	// Predefined grantees (temporary until backend provides these)
 	@state() private availableGrantees: { label: string; value: string }[] = [];
@@ -201,12 +200,6 @@ export class AddVinElement extends BaseOnboardingElement {
         this.selectedPendingVehicles = event.detail.selectedVehicles;
         this.selectedImeis = event.detail.selectedImeis;
         this.selectedVinsForSubmission = [...this.selectedPendingVehicles];
-
-        // Build VIN to IMEI mapping
-        this.vinToImeiMap.clear();
-        for (let i = 0; i < this.selectedPendingVehicles.length; i++) {
-            this.vinToImeiMap.set(this.selectedPendingVehicles[i], this.selectedImeis[i]);
-        }
 
         console.log("Selected pending vehicles:", this.selectedPendingVehicles);
         console.log("Selected IMEIs:", this.selectedImeis);
@@ -503,13 +496,9 @@ export class AddVinElement extends BaseOnboardingElement {
             };
             this.settings.saveSharingInfo();
 
-            const status = await this.onboardVINs(vehicles, sacdInput);
-            if (!status) {
-                // Handle failure case if needed
-            } else {
-                // Add inventory state records for successfully minted vehicles
-                await this.addInventoryStatesForVehicles(vehicles);
-            }
+            // The backend onboarding worker writes the initial "Inventory" state
+            // when the mint succeeds, so no frontend write is needed here.
+            await this.onboardVINs(vehicles, sacdInput);
         } catch (e) {
             this.displayFailure(msg("failed to onboard vins: ") + e);
             throw e; // Re-throw so caller can handle if needed
@@ -517,40 +506,5 @@ export class AddVinElement extends BaseOnboardingElement {
 
         await delay(5000);
         this.dispatchItemChanged();
-    }
-
-    private async addInventoryStatesForVehicles(vehicles: VehicleWithDefinition[]) {
-        console.log("Adding inventory states for successfully minted vehicles");
-
-        for (const vehicle of vehicles) {
-            const imei = this.vinToImeiMap.get(vehicle.vin);
-            if (!imei) {
-                console.warn(`No IMEI found for VIN ${vehicle.vin}, skipping inventory state`);
-                continue;
-            }
-
-            try {
-                const payload = {
-                    state: "Inventory",
-                    note: "Vehicle minted"
-                };
-
-                const response = await this.api.callApi<any>(
-                    'POST',
-                    `/fleet/vehicles/${imei}/inventory`,
-                    payload,
-                    true, // auth required
-                    true  // oracle endpoint
-                );
-
-                if (!response.success) {
-                    console.error(`Failed to add inventory state for VIN ${vehicle.vin} (IMEI ${imei}):`, response.error);
-                } else {
-                    console.log(`Successfully added inventory state for VIN ${vehicle.vin} (IMEI ${imei})`);
-                }
-            } catch (error) {
-                console.error(`Error adding inventory state for VIN ${vehicle.vin} (IMEI ${imei}):`, error);
-            }
-        }
     }
 }

--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -459,13 +459,8 @@ export class TransferModalElement extends BaseOnboardingElement {
         }
         this.statusMessage = msg("Transfer completed successfully");
 
-        // Add inventory state record
-        this.statusMessage = msg("Recording inventory state change...");
-        const inventoryResult = await this.addInventoryState(this.imei, this.walletAddress);
-        if (!inventoryResult.success) {
-            console.error("Failed to add inventory state:", inventoryResult.error);
-            // Don't fail the whole transfer if inventory tracking fails
-        }
+        // The backend transfer job records the Customer inventory state when the
+        // transfer lands on chain, so no frontend write is needed here.
 
         await delay(500);
         this.processing = false;
@@ -493,23 +488,4 @@ export class TransferModalElement extends BaseOnboardingElement {
         };
     }
 
-    async addInventoryState(imei: string, walletAddress: string): Promise<Result<any, string>> {
-        const payload = {
-            state: "Customer",
-            note: `Transfer to customer ${walletAddress}`
-        };
-
-        const resp = await this.api.callApi<any>('POST', `/fleet/vehicles/${imei}/inventory`, payload, true, true);
-        if (!resp.success) {
-            return {
-                success: false,
-                error: resp.error || msg("Failed to add inventory state")
-            };
-        }
-
-        return {
-            success: true,
-            data: resp.data
-        };
-    }
 }

--- a/web/src/elements/update-inventory-modal-element.ts
+++ b/web/src/elements/update-inventory-modal-element.ts
@@ -3,6 +3,12 @@ import {msg} from '@lit/localize';
 import { customElement, property, state } from 'lit/decorators.js';
 import { globalStyles } from '../global-styles.ts';
 import { ApiService } from '@services/api-service.ts';
+import {
+  INVENTORY_STATE_CUSTOMER,
+  INVENTORY_STATE_DEALER_INVENTORY,
+  INVENTORY_STATE_INVENTORY,
+  inventoryStateLabel,
+} from '../utils/inventory-states.ts';
 
 @customElement('update-inventory-modal-element')
 export class UpdateInventoryModalElement extends LitElement {
@@ -63,9 +69,15 @@ export class UpdateInventoryModalElement extends LitElement {
                   .value=${this.selectedState}
                   @change=${this.handleStateChange}
                 >
-                  <option value="Inventory">${msg('Inventory')}</option>
-                  <option value="Customer">${msg('Customer')}</option>
+                  <option value=${INVENTORY_STATE_INVENTORY}>${inventoryStateLabel(INVENTORY_STATE_INVENTORY)}</option>
+                  <option value=${INVENTORY_STATE_CUSTOMER}>${inventoryStateLabel(INVENTORY_STATE_CUSTOMER)}</option>
+                  <option value=${INVENTORY_STATE_DEALER_INVENTORY}>${inventoryStateLabel(INVENTORY_STATE_DEALER_INVENTORY)}</option>
                 </select>
+                ${this.selectedState === INVENTORY_STATE_DEALER_INVENTORY ? html`
+                  <div style="font-size: 13px; color: #666; margin-top: 8px;">
+                    ${msg('Vehicles in Dealer Inventory / Standby are not billed. At most 3% of your connected fleet can be in this state.')}
+                  </div>
+                ` : nothing}
               </div>
 
               <div>

--- a/web/src/generated/locales/es.ts
+++ b/web/src/generated/locales/es.ts
@@ -5,8 +5,8 @@
     import {html} from 'lit';
     import {str} from '@lit/localize';
 
-    /* eslint-disable no-irregular-whitespace */
-    /* eslint-disable @typescript-eslint/no-explicit-any */
+     
+     
 
     export const templates = {
       'h104d0372d43faa07': html`Para conectar su flota necesitará una cuenta de desarrollador DIMO. Si aún no tiene una, cree una en <a href="https://console.dimo.org" target="_blank">console.dimo.org</a>.`,
@@ -41,6 +41,7 @@
 's091d3407b5b2f824': `O`,
 's091d3d07b5b3076f': `OK`,
 's09241907b5b8e8f1': `IO`,
+'s0934cd8f1f0d223d': `Conectados menos Inventario del Concesionario / En Espera`,
 's096870834409c059': `Acuñado el`,
 's097b8b53f3d7f13e': `Agregar Nuevo Inquilino`,
 's0a11c2ffb8309d1a': `No encontrado`,
@@ -99,6 +100,7 @@
 's1e9160456cf320df': `Error al Eliminar`,
 's1f0d05eb8a0e0f3f': `Inventario`,
 's1f2a7c84b9784d52': `Licencia de Desarrollador 0x Client ID`,
+'s201c9c90f7f5ccf8': `Inventario del Concesionario / En Espera`,
 's208ff236d16dca19': `¿Está seguro de que desea desconectar el vehículo?`,
 's21d83df228901500': `Error al eliminar usuario administrador.`,
 's21f68e65dbf5b5a4': `Procesando...`,
@@ -109,7 +111,6 @@
 's22fa1ffafd6adf06': `+ Placa`,
 's22ff40785c781ed0': `Error al Desconectar`,
 's233ae776268cd44b': `Empresa`,
-'s238a02fdbce1b187': `Registrando cambio de estado de inventario...`,
 's239708c2cf30d3a8': `Ocurrió un error inesperado al eliminar el vehículo.`,
 's240732794d597f70': `Martes`,
 's246144d94749cb33': `Esto desconectará y eliminará el vehículo. ¿Está seguro?`,
@@ -171,6 +172,7 @@
 's3a231b3f6a7cdeb4': `Propiedad del Cliente`,
 's3a8601d715da564b': `Genere un enlace temporal para compartir el seguimiento del vehículo en vivo.`,
 's3ab3b951f86a542f': `Buscar grupos...`,
+'s3ac1ea08482df1d1': `Cambiar Estado`,
 's3bce12db754e774f': `Reclamar nuevo IMEI`,
 's3bd128de03e7e2c3': `Actualizando...`,
 's3c05fa34487c7a9e': `Estado de la Cuenta`,
@@ -359,6 +361,7 @@
 's7cff7b8a99de26ef': `1 lectura por hora`,
 's7d32c3d09009bb5e': `Error al conectar vehículo`,
 's7da178cd5e1c395e': `DIMO Secret`,
+'s7e24010b03787d8b': `Los vehículos en Inventario del Concesionario / En Espera no se facturan. Como máximo el 3% de su flota conectada puede estar en este estado.`,
 's7f0235d2ac159249': `Resultado de Registro`,
 's7f5869b3d14d7cbc': `Proveedor`,
 's80d410d589eae08a': `Cargando seguimiento del vehículo...`,
@@ -447,7 +450,6 @@
 's9a453768c4472e07': `Sincronizar SIMs y Flota`,
 's9a8e784897a942dd': `Incorporados y acuñados`,
 's9b16f99b17c2462b': `marca_modelo_año`,
-'s9b7f299c18dc9703': `Error al agregar estado de inventario`,
 's9c4f8150cfbba2e2': `Subir una atestación de documento`,
 's9cef4f0964a3bc87': `Error al cargar datos de telemetría e identidad`,
 's9d3ec532a393026d': str`Registro ${0} de ${1}`,
@@ -692,6 +694,7 @@
 'sfce4234dff6e2947': `Error al eliminar vehículo pendiente`,
 'sfd4aadec2ada796a': `No se encontraron resultados, asegúrese de haber`,
 'sfd4e03bfca6b24fb': `Error al restablecer datos de telemetría`,
+'sfd98c3fd50d281c5': `Vehículos Facturables`,
 'sfe8c6231f61dff73': `Actualizar Definición de Dispositivo`,
 'sfec13d5bbf592117': `Tiempo de ejecución`,
 'sff29be900b3b70eb': `Crear Nuevo Reporte`,

--- a/web/src/global-styles.ts
+++ b/web/src/global-styles.ts
@@ -408,6 +408,11 @@ export const globalStyles = css`
         color: #856404;
     }
 
+    .status-dealerinventory {
+        background: #e2e3e5;
+        color: #383d41;
+    }
+
     .status-not-owned {
         background: #ffe5b4;
         color: #856404;

--- a/web/src/utils/inventory-states.ts
+++ b/web/src/utils/inventory-states.ts
@@ -1,0 +1,24 @@
+import { msg } from '@lit/localize';
+
+// Inventory state values as stored by kaufmann-oracle in vin_inventory_states.
+// Keep in sync with internal/inventory/inventory.go in the oracle repo.
+export const INVENTORY_STATE_INVENTORY = 'Inventory';
+export const INVENTORY_STATE_CUSTOMER = 'Customer';
+export const INVENTORY_STATE_DEALER_INVENTORY = 'DealerInventory';
+
+export function inventoryStateLabel(state: string): string {
+  switch (state) {
+    case INVENTORY_STATE_INVENTORY:
+      return msg('Inventory');
+    case INVENTORY_STATE_CUSTOMER:
+      return msg('Customer');
+    case INVENTORY_STATE_DEALER_INVENTORY:
+      return msg('Dealer Inventory / Standby');
+    default:
+      return state;
+  }
+}
+
+export function inventoryStateClass(state: string): string {
+  return state ? `status-${state.toLowerCase()}` : '';
+}

--- a/web/src/views/home.ts
+++ b/web/src/views/home.ts
@@ -10,6 +10,7 @@ interface DashboardStats {
   total_vehicles: number;
   connected: number;
   pending_onboard: number;
+  billable_vehicles: number;
 }
 
 @customElement('home-view')
@@ -69,6 +70,11 @@ export class HomeView extends LitElement {
                     <div class="tile-label">${msg('Pending Onboard')}</div>
                     <div class="tile-value">${this.loading ? '—' : this.stats?.pending_onboard ?? 0}</div>
                     <div class="tile-subtitle">${msg('Devices existing but not minted')}</div>
+                </div>
+                <div class="tile">
+                    <div class="tile-label">${msg('Billable Vehicles')}</div>
+                    <div class="tile-value">${this.loading ? '—' : this.stats?.billable_vehicles ?? 0}</div>
+                    <div class="tile-subtitle">${msg('Connected minus Dealer Inventory / Standby')}</div>
                 </div>
             </div>
         </div>

--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -14,6 +14,7 @@ import {OracleTenantService} from '@services/oracle-tenant-service.ts';
 import {SettingsService} from '@services/settings-service.ts';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import {inventoryStateClass, inventoryStateLabel} from '../utils/inventory-states.ts';
 import '../elements/update-inventory-modal-element';
 import '../elements/fleet-map';
 import '../elements/click-to-copy-element';
@@ -886,10 +887,13 @@ export class VehicleDetailView extends LitElement {
                 </div>
                 <div>
                   <span class="status status-connected">${msg('Connected')}</span>
-                  <span class="status status-${(this.vehicle?.inventory || 'Inventory').toLowerCase()}"
+                  <span class="status ${inventoryStateClass(this.vehicle?.inventory || 'Inventory')}"
                         style="cursor: pointer;"
                         @click=${this.openInventoryModal}
-                        title="${msg('Click to update inventory status')}">${this.vehicle?.inventory || msg('Inventory')}</span>
+                        title="${msg('Click to update inventory status')}">${inventoryStateLabel(this.vehicle?.inventory || 'Inventory')}</span>
+                  <button class="btn btn-sm" style="margin-left: 8px; vertical-align: middle;" @click=${this.openInventoryModal}>
+                    ${msg('Change Status')}
+                  </button>
                   ${this.vehicle?.groups?.map(group => html`<span class="badge" style="background-color: ${group.color}; color: #fff;">${group.name}</span>`)}
                 </div>
               </div>
@@ -1226,7 +1230,7 @@ export class VehicleDetailView extends LitElement {
                   <tbody>
                   ${this.vehicle?.inventory_audit && this.vehicle.inventory_audit.length > 0 ? this.vehicle.inventory_audit.map(audit => html`
                     <tr>
-                      <td><span class="status status-${audit.state.toLowerCase()}">${audit.state}</span></td>
+                      <td><span class="status ${inventoryStateClass(audit.state)}">${inventoryStateLabel(audit.state)}</span></td>
                       <td>${audit.note}</td>
                       <td>${this.formatLastTelemetry(audit.created_at)}</td>
                     </tr>

--- a/web/src/views/vehicles-fleets.ts
+++ b/web/src/views/vehicles-fleets.ts
@@ -9,6 +9,7 @@ import { FleetService, FleetGroup } from '@services/fleet-service.ts';
 import { SettingsService } from '@services/settings-service.ts';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { inventoryStateClass, inventoryStateLabel } from '../utils/inventory-states.ts';
 
 dayjs.extend(relativeTime);
 
@@ -523,7 +524,7 @@ export class VehiclesFleetsView extends LitElement {
   }
 
   private getInventoryClass(inventory: string): string {
-    return inventory ? `status-${inventory.toLowerCase()}` : '';
+    return inventoryStateClass(inventory);
   }
 
   private getEngineClass(engine: string): string {
@@ -715,7 +716,7 @@ export class VehiclesFleetsView extends LitElement {
                             <td>${vehicle.vin}</td>
                             <td><span class="status ${this.getStatusClass(vehicle.connection_status)}">${vehicle.connection_status}</span></td>
                             <td title="${vehicle.last_telemetry}">${this.formatLastTelemetry(vehicle.last_telemetry)}</td>
-                            <td>${vehicle.inventory ? html`<span class="status ${this.getInventoryClass(vehicle.inventory)}">${vehicle.inventory}</span>` : '—'}</td>
+                            <td>${vehicle.inventory ? html`<span class="status ${this.getInventoryClass(vehicle.inventory)}">${inventoryStateLabel(vehicle.inventory)}</span>` : '—'}</td>
                             <td>${vehicle.groups.length > 0 ? vehicle.groups.map(group => html`<span class="badge" style="background-color: ${group.color}; color: #fff;">${group.name}</span>`) : '—'}</td>
                             <td>${vehicle.odometer || '—'}</td>
                             <td><span class="status ${this.getEngineClass(vehicle.engine)}">${this.getEngineDisplay(vehicle.engine)}</span></td>

--- a/web/xliff/es.xlf
+++ b/web/xliff/es.xlf
@@ -858,17 +858,9 @@
   <source>Check Info for final transfer verification</source>
   <target>Verifique la información para la verificación final de transferencia</target>
 </trans-unit>
-<trans-unit id="s238a02fdbce1b187">
-  <source>Recording inventory state change...</source>
-  <target>Registrando cambio de estado de inventario...</target>
-</trans-unit>
 <trans-unit id="s7bf37ab2a7b802cc">
   <source>Failed to create account</source>
   <target>Error al crear cuenta</target>
-</trans-unit>
-<trans-unit id="s9b7f299c18dc9703">
-  <source>Failed to add inventory state</source>
-  <target>Error al agregar estado de inventario</target>
 </trans-unit>
 <trans-unit id="sd8e49265fe5a495a">
   <source>Update Inventory Status</source>
@@ -2757,6 +2749,26 @@
 <trans-unit id="s4de430b40c94e903">
   <source>Resolve</source>
   <target>Resolver</target>
+</trans-unit>
+<trans-unit id="s7e24010b03787d8b">
+  <source>Vehicles in Dealer Inventory / Standby are not billed. At most 3% of your connected fleet can be in this state.</source>
+  <target>Los vehículos en Inventario del Concesionario / En Espera no se facturan. Como máximo el 3% de su flota conectada puede estar en este estado.</target>
+</trans-unit>
+<trans-unit id="s201c9c90f7f5ccf8">
+  <source>Dealer Inventory / Standby</source>
+  <target>Inventario del Concesionario / En Espera</target>
+</trans-unit>
+<trans-unit id="sfd98c3fd50d281c5">
+  <source>Billable Vehicles</source>
+  <target>Vehículos Facturables</target>
+</trans-unit>
+<trans-unit id="s0934cd8f1f0d223d">
+  <source>Connected minus Dealer Inventory / Standby</source>
+  <target>Conectados menos Inventario del Concesionario / En Espera</target>
+</trans-unit>
+<trans-unit id="s3ac1ea08482df1d1">
+  <source>Change Status</source>
+  <target>Cambiar Estado</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
## Description

Frontend for the Dealer Inventory / Standby feature (pairs with DIMO-Network/kaufmann-oracle#144 — merge that first).

### Changes made:
- **Dashboard**: new "Billable Vehicles" tile showing `billable_vehicles` from the stats endpoint (connected minus Dealer Inventory / Standby); wraps to a second row in the existing tiles grid.
- **Update-inventory modal**: third option "Dealer Inventory / Standby" with an inline hint that vehicles in this state are not billed and at most 3% of the connected fleet can be in it. The backend's 422 cap error surfaces in the modal's error box.
- **Vehicle detail**: explicit "Change Status" button next to the status pill — the pill-click was easy to miss as the only entry point; the pill remains clickable.
- **Shared `utils/inventory-states.ts`**: maps stored state values (`Inventory` / `Customer` / `DealerInventory`) to localized labels and `status-*` CSS classes, used by the modal, detail pill, inventory audit table, and vehicles list. Added a gray `.status-dealerinventory` pill style.
- **Removed frontend best-effort inventory writes**: post-mint `Inventory` (add-vin-element) and post-transfer `Customer` (transfer-modal-element) — the oracle now writes both server-side (initial state at mint success, Customer at transfer-job success), so the frontend writes would duplicate audit rows.
- **i18n**: extracted and translated the five new strings to Spanish; rebuilt the generated catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfzZa7tfgd9cbcDrftWv1S