### PR TITLE
feat: show device type in pending vehicles list

### DIFF
--- a/web/src/elements/pending-vehicles-element.ts
+++ b/web/src/elements/pending-vehicles-element.ts
@@ -9,7 +9,21 @@ import './claim-imei-modal-element';
 interface PendingVehicle {
     vin: string;
     imei: string;
+    deviceType: string;
     firstSeen: string;
+}
+
+// deviceTypeLabel maps the oracle's device_type to a human-friendly name. New
+// device types fall back to the raw value so they are visible rather than hidden.
+function deviceTypeLabel(deviceType: string): string {
+    switch (deviceType) {
+        case 'smart5':
+            return 'Ruptela Smart5';
+        case 'gv58':
+            return 'Kamaleon GV58';
+        default:
+            return deviceType || 'Unknown';
+    }
 }
 
 interface PendingVehiclesResponse {
@@ -173,6 +187,7 @@ export class PendingVehiclesElement extends LitElement {
                             </th>
                             <th>${msg('VIN')}</th>
                             <th>${msg('IMEI')}</th>
+                            <th>${msg('Device')}</th>
                             <th>${msg('First Seen')}</th>
                             <th>${msg('Action')}</th>
                         </tr>
@@ -180,11 +195,11 @@ export class PendingVehiclesElement extends LitElement {
                         <tbody>
                         ${this.items.length === 0 ? html`
                         <tr>
-                            <td colspan="5" style="text-align: center; padding: 2rem; color: #666;">
+                            <td colspan="6" style="text-align: center; padding: 2rem; color: #666;">
                                 ${msg('No results found, make sure you have')} <a href="#" @click=${(e: Event) => { e.preventDefault(); this.openClaimImeiModal(); }} style="color: #007bff; text-decoration: underline; cursor: pointer;">${msg('claimed')}</a> ${msg('your devices')}
                             </td>
                         </tr>
-                        ` : repeat(this.items, (item) => item.vin, (item) => html`
+                        ` : repeat(this.items, (item) => item.imei, (item) => html`
                         <tr>
                             <td>
                                 <input type="checkbox"
@@ -199,6 +214,7 @@ export class PendingVehiclesElement extends LitElement {
                             </td>
                             <td>${item.vin || msg('N/A')}</td>
                             <td>${item.imei}</td>
+                            <td>${deviceTypeLabel(item.deviceType)}</td>
                             <td>${item.firstSeen}</td>
                             <td>
                                 <button class="action-btn" @click=${() => this.openTelemetryModal(item.imei, item.vin)} style="margin-left: 0.5rem;">


### PR DESCRIPTION
## Description
Adds a **Device** column to the "Pending to onboard vehicles" list so an operator can see what kind of hardware each pre-mint device is — **Ruptela Smart5** or **Kamaleon GV58** (Queclink, via the flespi proxy) — using the oracle's new pending-vehicles `deviceType` field (kaufmann-oracle #165).

Kamaleon devices are seen **without a VIN** before onboarding, so device type is often the only field that distinguishes them in this list.

### Changes
- `PendingVehicle` interface: add `deviceType`.
- New "Device" column rendering a friendly label (`deviceTypeLabel`): `smart5` → "Ruptela Smart5", `gv58` → "Kamaleon GV58", anything else → its raw value (so a new device type is visible, not hidden).
- Row `repeat()` is now keyed by **IMEI** instead of VIN. VIN is empty for Kamaleon devices pre-onboarding, so multiple such rows would collide on an empty key; IMEI is always unique.
- Empty-state colspan bumped 5 → 6.

Typecheck (`tsc --noEmit`) and eslint pass (no new warnings).

### Follow-up (not in this PR)
The post-mint vehicle detail view still hardcodes a `Smart5 | IMEI: …` label (`vehicle-detail.ts`); branching that on device type needs `deviceType` added to the onboarded-vehicles API response too. Tracked for a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
