### PR TITLE
feat: manual VIN entry for GV58 in telemetry modal + device_type label

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -94,6 +94,7 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	// pending vehicles
 	oracleApp.Get("/pending-vehicles", genericProxyCtrl.Proxy)
 	oracleApp.Post("/pending-vehicles/claim/:imei", genericProxyCtrl.Proxy)
+	oracleApp.Post("/pending-vehicle/vin-to-imei/:imei", genericProxyCtrl.Proxy)
 	oracleApp.Delete("/pending-vehicle/vin-to-imei/:imei", genericProxyCtrl.Proxy)
 	oracleApp.Get("/pending-vehicle-telemetry/:imei", genericProxyCtrl.Proxy)
 	oracleApp.Delete("/pending-vehicle-telemetry/:imei", genericProxyCtrl.Proxy)

--- a/web/src/elements/pending-vehicles-element.ts
+++ b/web/src/elements/pending-vehicles-element.ts
@@ -249,7 +249,13 @@ export class PendingVehiclesElement extends LitElement {
         modal.addEventListener('modal-closed', () => {
             document.body.removeChild(modal);
         });
-        
+
+        // A manually-entered VIN (Kamaleon/GV58 devices don't report one) means this row can now
+        // be selected for minting — reload the list so its VIN and enabled checkbox show up.
+        modal.addEventListener('vin-associated', async () => {
+            await this.loadPendingVehicles();
+        });
+
         // Add to body
         document.body.appendChild(modal);
         

--- a/web/src/elements/telemetry-modal-element.ts
+++ b/web/src/elements/telemetry-modal-element.ts
@@ -59,6 +59,17 @@ export class TelemetryModalElement extends LitElement {
     @state()
     private showRemoveVinConfirm = false;
 
+    // Manual VIN entry — Kamaleon/GV58 devices don't transmit a VIN, so an operator must supply
+    // one before the vehicle can be selected for minting in the pending list.
+    @state()
+    private vinInput = "";
+
+    @state()
+    private savingVin = false;
+
+    @state()
+    private vinError = "";
+
     @state()
     private odometerDisplay: string = "—";
 
@@ -171,9 +182,33 @@ export class TelemetryModalElement extends LitElement {
                             <button type="button" class="modal-close" @click=${this.closeModal}>×</button>
                         </div>
                     </div>
+                    ${!this.vin ? html`
+                    <div style="padding: 1rem 1.5rem; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; background: #fffbeb;">
+                        <span style="font-weight: 600; color: #92400e;">${msg('No VIN on file')}</span>
+                        <span style="font-size: 0.85rem; color: #92400e;">${msg('This device does not report a VIN. Enter it to enable onboarding.')}</span>
+                        <input
+                            type="text"
+                            .placeholder=${msg('Enter VIN')}
+                            .value=${this.vinInput}
+                            @input=${(e: InputEvent) => { this.vinInput = (e.target as HTMLInputElement).value; this.vinError = ""; }}
+                            @keydown=${(e: KeyboardEvent) => { if (e.key === 'Enter') this.saveVin(); }}
+                            ?disabled=${this.savingVin}
+                            maxlength="17"
+                            style="flex: 1; min-width: 180px; padding: 0.4rem 0.6rem; border: 1px solid #d1d5db; border-radius: 4px; font-family: monospace; text-transform: uppercase;"
+                        >
+                        <button type="button"
+                                class="btn btn-primary ${this.savingVin ? 'processing' : ''}"
+                                ?disabled=${this.savingVin || this.vinInput.trim().length <= 10}
+                                @click=${this.saveVin}
+                                style="font-size: 0.875rem; padding: 0.5rem 1rem;">
+                            ${this.savingVin ? msg('Saving...') : msg('Save VIN')}
+                        </button>
+                        ${this.vinError ? html`<div style="color: #dc2626; font-size: 0.85rem; flex-basis: 100%;">${this.vinError}</div>` : ''}
+                    </div>
+                    ` : nothing}
                     <div style="padding: 1rem 1.5rem; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 0.75rem;">
-                        <button type="button" 
-                                class="btn btn-danger" 
+                        <button type="button"
+                                class="btn btn-danger"
                                 ?disabled=${this.immobilizerLoading}
                                 @click=${this.immobilizerOn}
                                 style="font-size: 0.875rem; padding: 0.5rem 1rem; background-color: #dc2626; color: white; border: none; border-radius: 0.375rem; cursor: pointer;">
@@ -322,6 +357,9 @@ export class TelemetryModalElement extends LitElement {
         this.resetting = false;
         this.removingVin = false;
         this.showRemoveVinConfirm = false;
+        this.vinInput = "";
+        this.savingVin = false;
+        this.vinError = "";
         this.immobilizerLoading = false;
         this.immobilizerError = "";
         this.odometerDisplay = "—";
@@ -407,6 +445,50 @@ export class TelemetryModalElement extends LitElement {
             console.error("Error deleting pending vehicle:", err);
         } finally {
             this.removingVin = false;
+        }
+    }
+
+    // saveVin associates the operator-entered VIN with this device via the oracle, then notifies
+    // the parent (pending list) so the row reloads with its VIN and becomes selectable for minting.
+    private async saveVin() {
+        const vin = this.vinInput.trim().toUpperCase();
+        if (vin.length <= 10) {
+            this.vinError = msg("Please enter a valid VIN");
+            return;
+        }
+        if (!this.imei) {
+            this.vinError = msg("No IMEI provided");
+            return;
+        }
+
+        this.savingVin = true;
+        this.vinError = "";
+
+        try {
+            const response = await this.apiService.callApi(
+                'POST',
+                `/pending-vehicle/vin-to-imei/${this.imei}`,
+                { vin },
+                true,
+                true
+            );
+            if (response.success) {
+                this.vin = vin;
+                this.vinInput = "";
+                // Let the pending-vehicles list refresh so the newly-VINed row is mintable.
+                this.dispatchEvent(new CustomEvent('vin-associated', {
+                    detail: { imei: this.imei, vin },
+                    bubbles: true,
+                    composed: true
+                }));
+            } else {
+                this.vinError = response.error || msg("Failed to save VIN");
+            }
+        } catch (err) {
+            this.vinError = msg("Failed to save VIN");
+            console.error("Error saving VIN:", err);
+        } finally {
+            this.savingVin = false;
         }
     }
 

--- a/web/src/views/vehicle-detail.ts
+++ b/web/src/views/vehicle-detail.ts
@@ -147,6 +147,9 @@ interface Vehicle {
   inventory_audit: InventoryAudit[];
   vendor_data?: Record<string, string>;
   license_plate?: string;
+  // device_type identifies the telemetry hardware (oracle vins.device_type): "smart5" (Ruptela)
+  // or "gv58" (Queclink/Kamaleon via flespi). Drives the hardware label; may be absent on older rows.
+  device_type?: string;
   // owner is the last known on-chain owner stored in kaufmann's vins table. Identity is the
   // source of truth; we compare against it on detail load and PATCH back when it drifts.
   owner?: string;
@@ -1494,10 +1497,24 @@ export class VehicleDetailView extends LitElement {
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
   }
 
+  // deviceTypeLabel maps the oracle's vins.device_type to a human-friendly hardware name.
+  // Mirrors the label logic in pending-vehicles-element. Unknown/absent types fall back to
+  // "Ruptela Smart5" — smart5 is the DB column default and legacy rows predate the column.
+  private deviceTypeLabel(deviceType: string | undefined): string {
+    switch (deviceType) {
+      case 'gv58':
+        return 'Kamaleon GV58';
+      case 'smart5':
+        return 'Ruptela Smart5';
+      default:
+        return deviceType || 'Ruptela Smart5';
+    }
+  }
+
   private renderHardwareDetails(): string {
     const aftermarketDevice = this.vehicleIdentity?.vehicle?.aftermarketDevice;
     if (!aftermarketDevice) {
-      return `Smart5 | IMEI: ${this.vehicle?.imei || 'N/A'}`;
+      return `${this.deviceTypeLabel(this.vehicle?.device_type)} | IMEI: ${this.vehicle?.imei || 'N/A'}`;
     }
 
     const serial = aftermarketDevice.serial || 'N/A';


### PR DESCRIPTION
## Why

Kamaleon/GV58 devices don't transmit a VIN, so their pending-vehicle rows are VIN-less and the mint checkbox stays disabled — they can't be onboarded. This adds manual VIN entry where operators already go to confirm an install: the telemetry modal.

## Changes

- **Telemetry modal**: when a device has no VIN, show a "No VIN on file" bar with a VIN input + **Save VIN** (Enter to submit). On save → `POST /pending-vehicle/vin-to-imei/{imei} {vin}`, set the VIN locally, emit `vin-associated`.
- **Pending list**: reload on `vin-associated` so the newly-VINed row gets its VIN + enabled checkbox and is selectable for minting.
- **vehicle-detail**: branch the hardware label on the oracle's `device_type` (**Kamaleon GV58** / **Ruptela Smart5**) instead of hardcoding `Smart5`.
- **api**: proxy the new `POST /pending-vehicle/vin-to-imei/:imei` route.

## Depends on

`kaufmann-oracle` PR #171 (new endpoint + `device_type` on fleet-vehicle responses). **Merge/release that first** — the VIN save and device label need the oracle side deployed.

## Test

- api `go build` / `vet` / `gofmt` clean
- web `tsc --noEmit` clean; `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)