### PR TITLE
Remove force delete; remove deleted vehicle row optimistically

### DIFF
--- a/web/src/elements/vehicle-list-element.ts
+++ b/web/src/elements/vehicle-list-element.ts
@@ -75,11 +75,13 @@ export class VehicleListElement extends LitElement {
         super.connectedCallback();
         // Listen for bubbling item change events from row items
         this.addEventListener('item-changed', this.handleItemChanged as EventListener);
+        this.addEventListener('item-deleted', this.handleItemDeleted as EventListener);
         await this.loadVehicles();
     }
 
     disconnectedCallback(): void {
         this.removeEventListener('item-changed', this.handleItemChanged as EventListener);
+        this.removeEventListener('item-deleted', this.handleItemDeleted as EventListener);
         super.disconnectedCallback();
     }
 
@@ -116,6 +118,18 @@ export class VehicleListElement extends LitElement {
     private handleItemChanged = async () => {
         // Refresh the list when any row dispatches an item update event
         await this.loadVehicles();
+    };
+
+    // The backend delete may not be reflected in /vehicles right away, so drop the row
+    // locally rather than re-fetching a list that could still include it.
+    private handleItemDeleted = (e: CustomEvent<{ value?: Vehicle }>) => {
+        const deleted = e.detail?.value;
+        if (!deleted) return;
+        const remaining = this.items.filter((item) => item.id !== deleted.id);
+        if (remaining.length === this.items.length) return;
+        this.items = remaining;
+        this.totalItems = Math.max(0, this.totalItems - 1);
+        this.shouldShowPagination = this.totalItems > this.pageSize;
     };
 
     private async goToPage(page: number) {

--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -140,15 +140,6 @@ export class VehicleListItemElement extends BaseOnboardingElement {
                   >
                       ${msg('reset onboarding')}
                   </button>
-                  <button
-                      type="button"
-                      ?hidden=${this.item.tokenId == 0 || this.item.isCurrentUserOwner || this.item.isSharedAccountSigner}
-                      ?disabled=${this.processing}
-                      @click=${this.forceDeleteVehicle}
-                      class=${this.deletionProcessing ? 'processing action-btn secondary' : 'action-btn secondary'}
-                  >
-                      ${msg('force delete')}
-                  </button>
               </td>
             </tr>
           ` : nothing;
@@ -229,6 +220,14 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         }));
     }
 
+    private dispatchItemDeleted() {
+        this.dispatchEvent(new CustomEvent('item-deleted', {
+            detail: { value: this.item },
+            bubbles: true,
+            composed: true
+        }));
+    }
+
     async connectVehicle() {
         if (!this.item) {
             return;
@@ -303,39 +302,14 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         const result = sharedSigner
             ? await this.deleteSharedAccountVehicle(this.item.tokenId, this.item.vin)
             : await this.deleteVins([this.item.vin]);
+        this.processing = false;
+        this.deletionProcessing = false;
         if (result.success) {
-            await delay(5000);
-            this.processing = false;
-            this.deletionProcessing = false;
-            this.dispatchItemChanged();
+            // The backend delete can lag behind the response, so drop the row locally
+            // instead of re-fetching a list that may still contain it.
+            this.dispatchItemDeleted();
         } else {
-            this.processing = false;
-            this.deletionProcessing = false;
             this.openErrorModal(result.error || msg('Vehicle delete failed'), msg('Delete Failed'));
-        }
-    }
-
-    // abandons the NFT
-    async forceDeleteVehicle() {
-        if (!this.item) {
-            return;
-        }
-
-        if (!confirm(msg("Are you sure you want to FORCE delete this vehicle? This will abandon all the vehicle history attached to their NFT. Only do this if you are unable to get access to vehicle NFT."))) {
-            return;
-        }
-
-        this.processing = true;
-        this.deletionProcessing = true;
-        const result = await this.api.callApi('DELETE', `/vehicle/force/${this.item.imei}`, null, true, true);
-        if (result.success) {
-            this.processing = false;
-            this.deletionProcessing = false;
-            this.dispatchItemChanged();
-        } else {
-            this.processing = false;
-            this.deletionProcessing = false;
-            this.openErrorModal(result.error || msg('Vehicle force delete failed'), msg('Force Delete Failed'));
         }
     }
 


### PR DESCRIPTION
## Summary

Two changes to the **ONBOARDED VEHICLES** panel on the onboarding view:

- **Removed the `force delete` button** and its `forceDeleteVehicle()` handler from `vehicle-list-item-element`. The backend route (`DELETE /vehicle/force/:imei`, `api/internal/app/app.go:171`) is untouched — it's just no longer reachable from the UI.
- **`delete` now removes the row immediately on success.** Previously it did `await delay(5000)` and then dispatched `item-changed`, which made `vehicle-list-element` refetch `/vehicles`. That meant a 5-second stall, and because the backend delete can lag behind its response, the refetched list could still contain the deleted vehicle and the row would reappear. Now the item dispatches a new `item-deleted` event and the list filters the row out locally, decrements `totalItems`, and recomputes `shouldShowPagination`.

## Notes

- The delete confirmation is a native `confirm()`, not a modal. The `error-modal-element` only shows on failure, and that path is unchanged — a failed delete leaves the row in place.
- `disconnect` still uses the old `delay(5000)` + full-reload pattern. Left as-is since the row legitimately remains after a disconnect, but the same 5s stall applies there.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npx eslint` on both changed files reports no new warnings (verified locally — only pre-existing `no-console` / `no-explicit-any`)
- [ ] Manually delete an onboarded vehicle and confirm the row disappears right away and the "Showing X of Y" count decrements
- [ ] Confirm no `force delete` button renders for externally-owned vehicles
- [ ] Trigger a failing delete and confirm the error modal still appears and the row stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cW3dbZF4HFCVVi15Tg74A