### PR TITLE
docs: operator console pointer + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent Guidelines — b2b-fleet-mgr-app
+
+## What this app is
+
+A **BFF, not a backend.** No database, no migrations. `api/internal/app/app.go`
+is largely one routing table where most entries are
+`oracleApp.<verb>(path, genericProxyCtrl.Proxy)` under `/oracle/:oracleID/*`,
+proxying to whichever oracle is selected (`kaufmann-oracle`, `motorq-oracle`,
+`tesla-oracle`, …). `oracleIDMiddleware` validates the oracle id against the
+configured list.
+
+The non-proxy handlers exist to build payloads for passkey signing (mint /
+transfer / disconnect / delete) and to talk to accounts-api for OTP login.
+
+**So: tenant and vehicle state lives in the oracle, not here.** If you're
+looking for where something is stored, it's upstream.
+
+Frontend is Vite + Lit + TypeScript in `web/`. Oracle and tenant selection are
+held in `localStorage` via `web/src/services/oracle-tenant-service.ts`.
+
+See `.planning/codebase/` for the fuller architecture, conventions, stack and
+testing notes, and `.planning/PROJECT.md` for the current milestone.
+
+## Tenancy — read this before touching tenant flow, users or vehicle assignment
+
+This app is becoming the **operator console** for an operator-managed
+multi-tenant model: one operator tenant configures customer sub-tenants, which
+end customers use in `fleet-lite-app`.
+
+Read [`docs/OPERATOR_TENANCY.md`](docs/OPERATOR_TENANCY.md) — it points at the
+full design set — before changing tenant selection, the users/admin screens, or
+`web/src/elements/add-vin-element.ts`.
+
+Things an agent will otherwise get wrong:
+
+- **This app and fleet-lite are different surfaces, not two views of one thing.**
+  Here you operate *as* the operator and see **every** vehicle; sub-tenants are
+  configuration objects you manage from the outside. You never "switch into" a
+  sub-tenant here.
+- **Operator staff are b2b-only.** There's no impersonation and no delegated
+  fleet-lite session. Don't build one.
+- **The SACD grantee should default to the operator's DIMO client id**, with the
+  picker behind an Advanced expander. A vehicle minted with the wrong grantee is
+  invisible to the operator and needs an on-chain fix.
+- **Only minted vehicles can be assigned** to a sub-tenant — entitlement is keyed
+  by vehicle token id, which an unminted VIN doesn't have.
+- Sub-tenants get **no SACD grants**; their access is web2 only.
+
+## Local development
+
+See [`README.md`](README.md). TL;DR: `make dev` brings up frontend + backend
+together. Needs `localdev.dimo.org` in `/etc/hosts` and the mkcert root CA
+trusted — passkeys require https and a `*.dimo.org` relying-party id.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/OPERATOR_TENANCY.md
+++ b/docs/OPERATOR_TENANCY.md
@@ -1,0 +1,95 @@
+# Operator-managed multi-tenancy — pointer
+
+The design for turning this app into an **operator console** — where one tenant
+configures and manages other tenants that end customers use in `fleet-lite-app` —
+lives in:
+
+> `../fleet-lite-app/docs/operator-tenancy/`
+
+(It's over there because the centrepiece is a new shared service that doesn't
+have a repo yet, and fleet-lite-app is the most affected app. It'll move when
+that repo exists.)
+
+## This app and fleet-lite are different surfaces
+
+Not two views of the same thing. The distinction drives most of the design:
+
+| | this app | `fleet-lite-app` |
+|---|---|---|
+| You operate **as** | the operator tenant | any tenant you can act in |
+| Vehicle scope | **every vehicle** in the operator's fleet | one tenant's slice |
+| Sub-tenants are | configuration objects you manage from the outside | the thing you're logged into |
+| Built for | thousands of vehicles — paged, searchable tables | **sub-500 fleets**, map-first |
+
+**You never "switch into" a sub-tenant here.** You stay the operator and
+configure the customer's fleet from the outside. And operator staff don't go into
+fleet-lite at all — **there is no impersonation and no delegated fleet-lite
+session**. That keeps this app's tenant selection simple (it selects an operator)
+which matters given the flow work already in `.planning/PROJECT.md`.
+
+An operator tenant *can* also appear in fleet-lite, controlled by a
+`fleet_lite_enabled` toggle that lives on this app's operator settings screen.
+Default on; turned off once the operator's fleet outgrows what fleet-lite is
+tuned for.
+
+## What it means for this repo
+
+Today this app is a BFF: no database, `/oracle/:oracleID/*` proxied to the
+selected oracle plus a handful of signing helpers. That doesn't change — it
+gains a second upstream.
+
+| Change | Phase |
+|---|---|
+| `/tenancy/*` upstream alongside `/oracle/:oracleID/*`, same generic proxy pattern | 3 |
+| **Customers** section: list, create, detail (Users / Vehicles / Settings) | 3 |
+| Provision customer users by email (accounts-api lookup-or-create → membership) | 3 |
+| Assign vehicles to a customer from the existing paged `GetFleetVehicles` view — **minted vehicles only** (an unminted VIN has no token id to entitle) | 3 |
+| Bulk-assign by **operator** fleet group, with drift re-apply. The group selects vehicles; it does not propagate into the customer's tenant — their groups are their own | 3 |
+| `fleet_lite_enabled` toggle on operator settings, with a nudge when the fleet outgrows fleet-lite | 3 |
+| Operator tenant + managed-customer tenant in the frontend tenant state | 3 |
+| **SACD grantee picker in `add-vin-element.ts` defaults automatically** to the operator's developer license; the picker demotes to an advanced override | 3 |
+
+## The mint flow is already right
+
+On-chain ownership already sits with the operator — `onboard.go:286` mints with
+`Owner: args.Owner`, the staff member signing here with their passkey. Customer
+tenants never hold the asset, so customer offboarding is a database operation, and
+"customer takes their vehicles" reuses the `/vehicle/transfer` flows this app
+already has.
+
+The one change worth making: the grantee checkbox list in `add-vin-element.ts`
+asks the person onboarding a vehicle to make a decision that, under the operator
+model, always has the same answer — the operator's developer license. A vehicle
+minted with the wrong grantee is invisible to the operator and needs an on-chain
+fix, so removing that opportunity is worth doing regardless of the tenancy work.
+
+## Sequencing
+
+Phase 3 touches `web/src/services/oracle-tenant-service.ts` and the app shell —
+the same surface as the tenant-flow hardening milestone in
+`.planning/PROJECT.md`. **Land that milestone first**; running both at once will
+conflict.
+
+## Decisions already locked
+
+1. A **new shared tenancy service** is the source of truth for tenants, users and
+   memberships — not this app, not the oracle.
+2. Customer tenants read DIMO data under the **operator's** developer license;
+   vehicle scoping is a database entitlement, not an on-chain SACD change.
+3. Vehicles are assigned **per vehicle**; fleet groups are bulk shorthand with
+   provenance recorded.
+4. Users get in **both** ways: operator provisions directly, and fleet-lite's
+   email-invitation flow stays.
+5. **On-chain does two things** — ownership (operator-held) and one SACD grant
+   for fleet enumeration. Sub-tenants get no SACD grants; customer access and
+   revocation are web2.
+6. **The two apps are different surfaces** (see above).
+7. **Operator staff are b2b-only** — no impersonation, no delegated fleet-lite
+   sessions. Delegation exists for management only.
+8. **Fleet group ids embed their tenant**: `<tenant-uuid>_<slug>`, fixing a live
+   collision and making group attestations attributable under a shared license.
+
+See `05-risks-and-open-questions.md` for the consequences — in particular that
+decisions 2 and 5 make tenant isolation our code's responsibility rather than
+the chain's, deliberately, and that the mitigations are therefore the isolation
+mechanism rather than defence in depth.


### PR DESCRIPTION
Docs only — no code changes.

## What

Under the operator-managed multi-tenancy design, this app becomes the **operator console**: one operator tenant creates and configures customer sub-tenants, manages their users, and assigns them vehicles. End customers use `fleet-lite-app`.

`docs/OPERATOR_TENANCY.md` points at the full design set (currently in `fleet-lite-app/docs/operator-tenancy/`, moving to the new service's repo when it exists) and records what lands here.

## The distinction that drives the design

This app and fleet-lite are **different surfaces, not two views of one thing**:

| | this app | fleet-lite-app |
|---|---|---|
| You operate as | the operator tenant | any tenant you can act in |
| Vehicle scope | **every vehicle** in the operator's fleet | one tenant's slice |
| Sub-tenants are | configuration objects you manage from the outside | the thing you're logged into |
| Built for | thousands of vehicles, paged/searchable | sub-500 fleets, map-first |

So you never "switch into" a sub-tenant here, and operator staff never go into fleet-lite — there's no impersonation and no delegated fleet-lite session.

## What changes here (Phase 3)

- `/tenancy/*` upstream alongside `/oracle/:oracleID/*`, same generic proxy pattern
- **Customers** section: list, create, detail (Users / Vehicles / Settings)
- Provision customer users by email; assign vehicles (minted only — an unminted VIN has no token id to entitle)
- `fleet_lite_enabled` toggle on operator settings
- **SACD grantee defaults to the operator's client id**, picker demoted to an Advanced expander. Worth doing regardless of the tenancy work: a vehicle minted with the wrong grantee is invisible to the operator and needs an on-chain fix

Sequence after the tenant-flow hardening milestone in `.planning/PROJECT.md` — both touch `oracle-tenant-service.ts` and the app shell.

## AGENTS.md

This repo had none. Adds one recording that the app is a BFF with no database (tenant state lives in the oracle), the surface distinction above, and the tenancy constraints. `CLAUDE.md` imports it — Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so without the importer none of it loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RifTN8ZabDWb1hW7XtBRcQ