### PR TITLE
fix: surface signing failures instead of spinning forever

### DIFF
--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -402,70 +402,77 @@ export class TransferModalElement extends BaseOnboardingElement {
         this.errorMessage = "";
         this.statusMessage = "";
 
-        console.log("Vehicle VIN:", this.vehicleVin);
-        console.log("Vehicle IMEI", this.imei);
-        console.log("Transfer Type:", transferType);
-        this.statusMessage = msg("Processing transfer for IMEI: ") + this.imei;
-        
-        if (transferType === 'email') {
-            if (this.emailLookupError) {
-                this.errorMessage = this.emailLookupError;
-                this.processing = false;
-                return;
-            }
+        // Everything below is wrapped so that a *thrown* error still reaches the user. The
+        // signing path can reject rather than return a failed Result (a dismissed passkey
+        // dialog is the common case), and this method is invoked straight from a click
+        // handler, so an escaping rejection previously left `processing` stuck at true — the
+        // modal spun forever showing neither an error nor any sign it had stopped.
+        try {
+            console.log("Vehicle VIN:", this.vehicleVin);
+            console.log("Vehicle IMEI", this.imei);
+            console.log("Transfer Type:", transferType);
+            this.statusMessage = msg("Processing transfer for IMEI: ") + this.imei;
 
-            if (this.emailAccountFound && this.resolvedEmailWallet) {
-                // Existing account: transfer straight to the resolved wallet — no account
-                // creation, no OTP email.
-                this.walletAddress = this.resolvedEmailWallet;
-                console.log("Transferring to existing account wallet:", this.walletAddress);
-                this.statusMessage = msg("Transferring to existing account: ") + this.walletAddress;
-            } else {
-                // New account: create it (user gets an OTP email) then transfer.
-                this.statusMessage = msg("Creating account for email: ") + this.email;
-                const createAccountResp = await this.createAccount(this.email);
-                if (!createAccountResp.success) {
-                    this.errorMessage = createAccountResp.error;
-                    this.processing = false;
+            if (transferType === 'email') {
+                if (this.emailLookupError) {
+                    this.errorMessage = this.emailLookupError;
                     return;
                 }
-                this.walletAddress = createAccountResp.data.walletAddress;
-                console.log("Created account with wallet address:", this.walletAddress);
-                this.statusMessage = msg("Account created with wallet address: ") + this.walletAddress;
+
+                if (this.emailAccountFound && this.resolvedEmailWallet) {
+                    // Existing account: transfer straight to the resolved wallet — no account
+                    // creation, no OTP email.
+                    this.walletAddress = this.resolvedEmailWallet;
+                    console.log("Transferring to existing account wallet:", this.walletAddress);
+                    this.statusMessage = msg("Transferring to existing account: ") + this.walletAddress;
+                } else {
+                    // New account: create it (user gets an OTP email) then transfer.
+                    this.statusMessage = msg("Creating account for email: ") + this.email;
+                    const createAccountResp = await this.createAccount(this.email);
+                    if (!createAccountResp.success) {
+                        this.errorMessage = createAccountResp.error;
+                        return;
+                    }
+                    this.walletAddress = createAccountResp.data.walletAddress;
+                    console.log("Created account with wallet address:", this.walletAddress);
+                    this.statusMessage = msg("Account created with wallet address: ") + this.walletAddress;
+                }
             }
-        }
 
-        if (this.walletAddress == "") {
-            alert(msg("Please enter a wallet address"));
-            this.processing = false;
-            return;
-        }
-
-        console.log("Target Wallet to transfer to", this.walletAddress);
-        // Shared-account vehicles can't be passkey-signed by the connected wallet (it isn't
-        // the owner). The backend signs server-side via the tenant signer.
-        const result = this.useSharedAccountFlow
-            ? await this.transferSharedAccountVehicle(this.tokenId, this.walletAddress)
-            : await this.transferVehicle(this.imei, this.walletAddress);
-        if (!result.success) {
-            if (result.error.toLowerCase().includes('timeout')) {
-                this.errorMessage = msg("Check Info for final transfer verification");
-            } else {
-                this.errorMessage = result.error;
-                this.processing = false;
+            if (this.walletAddress == "") {
+                this.errorMessage = msg("Please enter a wallet address");
                 return;
             }
 
+            console.log("Target Wallet to transfer to", this.walletAddress);
+            // Shared-account vehicles can't be passkey-signed by the connected wallet (it isn't
+            // the owner). The backend signs server-side via the tenant signer.
+            const result = this.useSharedAccountFlow
+                ? await this.transferSharedAccountVehicle(this.tokenId, this.walletAddress)
+                : await this.transferVehicle(this.imei, this.walletAddress);
+            if (!result.success) {
+                if (result.error.toLowerCase().includes('timeout')) {
+                    this.errorMessage = msg("Check Info for final transfer verification");
+                } else {
+                    this.errorMessage = result.error;
+                    return;
+                }
+
+            }
+            this.statusMessage = msg("Transfer completed successfully");
+
+            // The backend transfer job records the Customer inventory state when the
+            // transfer lands on chain, so no frontend write is needed here.
+
+            await delay(500);
+
+            this.closeModal();
+        } catch (error: any) {
+            console.error("Transfer failed:", error?.message, error?.stack);
+            this.errorMessage = error?.message || msg("Transfer failed unexpectedly");
+        } finally {
+            this.processing = false;
         }
-        this.statusMessage = msg("Transfer completed successfully");
-
-        // The backend transfer job records the Customer inventory state when the
-        // transfer lands on chain, so no frontend write is needed here.
-
-        await delay(500);
-        this.processing = false;
-
-        this.closeModal();
     }
 
     async createAccount(email:string): Promise<Result<AccountData, string>> {

--- a/web/src/services/signing-service.ts
+++ b/web/src/services/signing-service.ts
@@ -16,6 +16,44 @@ const SIGNING_SERVICE_SESSION_KEY = "signingServiceSession";
 const SIGNING_SERVICE_WALLET_KEY = "signingServiceWallet";
 const SESSION_TIME_S = 30 * 60;
 
+// Nothing in the Turnkey/ZeroDev chain below imposes a deadline of its own: the passkey
+// prompt (createReadWriteSession) is a WebAuthn call that can sit unresolved indefinitely,
+// and the Turnkey and RPC fetches have no timeout either. An unbounded await here never
+// settles the caller's promise, which leaves the calling modal spinning with no error and no
+// network request — the failure mode is invisible in both the UI and the server logs.
+const PASSKEY_TIMEOUT_MS = 120_000;
+const NETWORK_TIMEOUT_MS = 30_000;
+
+// withTimeout rejects if the operation has not settled in time. The underlying work is not
+// cancellable (WebAuthn and fetch both keep running), so this bounds what the *caller* waits
+// for rather than aborting the operation itself.
+function withTimeout<T>(operation: Promise<T>, ms: number, label: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s. Please try again.`)),
+            ms,
+        );
+        operation.then(
+            value => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            error => {
+                clearTimeout(timer);
+                reject(error);
+            },
+        );
+    });
+}
+
+// SigningResult keeps `signature` and `error` on one non-discriminated shape, which is how
+// every caller reads it (`if (!res.success || !res.signature) { ...res.error }`).
+interface SigningResult {
+    success: boolean;
+    signature?: any;
+    error?: string;
+}
+
 interface SigningServiceSession {
     organizationId: {
         organizationId: string;
@@ -40,7 +78,9 @@ export class SigningService {
         return SigningService.instance;
     }
 
-    public async signUserOperation(payload: any) {
+    // The return type is stated explicitly so that callers can keep reading `.signature` and
+    // `.error` off a single value; buildKernelAccount's discriminated union stays internal.
+    public async signUserOperation(payload: any): Promise<SigningResult> {
         const settings = this.settings.privateSettings;
         const accountInfo = this.settings.accountInfo;
 
@@ -51,47 +91,17 @@ export class SigningService {
             };
         }
 
-        const {turnkeyApiUrl, turnkeyOrgId, turnkeyRpId} = settings;
-        const {subOrganizationId} = accountInfo;
-
-        const turnkeyClient = await this.getTurnkeyClient(turnkeyApiUrl, turnkeyRpId, turnkeyOrgId, subOrganizationId);
-
-        if (!turnkeyClient) {
-            return {
-                success: false,
-                error: "Failed to get turnkey client"
-            };
-        }
-
-        const wallet = await this.getTurnkeyWallet(turnkeyClient, subOrganizationId);
-
         try {
-            const turnkeyAccount = await createAccount({
-                client: turnkeyClient,
-                organizationId: accountInfo.subOrganizationId,
-                signWith: wallet,
-            });
+            const kernelAccount = await this.buildKernelAccount(settings, accountInfo);
+            if (!kernelAccount.success) {
+                return kernelAccount;
+            }
 
-            const publicClient = createPublicClient({
-                transport: http(settings.rpcUrl),
-                chain: settings.environment === 'prod' ? polygon : polygonAmoy,
-            });
-
-            const ecdsaValidator = await signerToEcdsaValidator(publicClient, {
-                signer: turnkeyAccount,
-                entryPoint: getEntryPoint("0.7"),
-                kernelVersion: KERNEL_V3_1
-            });
-
-            const kernelAccount = await createKernelAccount(publicClient, {
-                plugins: {
-                    sudo: ecdsaValidator,
-                },
-                entryPoint: getEntryPoint("0.7"),
-                kernelVersion: KERNEL_V3_1,
-            });
-
-            const signature = await kernelAccount?.signUserOperation(payload);
+            const signature = await withTimeout(
+                kernelAccount.account.signUserOperation(payload),
+                PASSKEY_TIMEOUT_MS,
+                "Signing the transaction",
+            );
             return {
                 success: true,
                 signature: signature,
@@ -107,7 +117,7 @@ export class SigningService {
         }
     }
 
-    public async signTypedData(payload: any) {
+    public async signTypedData(payload: any): Promise<SigningResult> {
         const settings = this.settings.privateSettings;
         const accountInfo = this.settings.accountInfo;
 
@@ -118,46 +128,17 @@ export class SigningService {
             };
         }
 
-        const {turnkeyApiUrl, turnkeyOrgId, turnkeyRpId} = settings;
-        const {subOrganizationId} = accountInfo;
-
-        const turnkeyClient = await this.getTurnkeyClient(turnkeyApiUrl, turnkeyRpId, turnkeyOrgId, subOrganizationId);
-
-        if (!turnkeyClient) {
-            return {
-                success: false,
-                error: "Failed to get turnkey client"
-            };
-        }
-
-        const wallet = await this.getTurnkeyWallet(turnkeyClient, subOrganizationId);
-
         try {
-            const turnkeyAccount = await createAccount({
-                client: turnkeyClient,
-                organizationId: accountInfo.subOrganizationId,
-                signWith: wallet,
-            });
+            const kernelAccount = await this.buildKernelAccount(settings, accountInfo);
+            if (!kernelAccount.success) {
+                return kernelAccount;
+            }
 
-            const publicClient = createPublicClient({
-                transport: http(settings.rpcUrl),
-                chain: settings.environment === 'prod' ? polygon : polygonAmoy,
-            });
-
-            const ecdsaValidator = await signerToEcdsaValidator(publicClient, {
-                signer: turnkeyAccount,
-                entryPoint: getEntryPoint("0.7"),
-                kernelVersion: KERNEL_V3_1
-            });
-
-            const kernelAccount = await createKernelAccount(publicClient, {
-                plugins: {
-                    sudo: ecdsaValidator,
-                },
-                entryPoint: getEntryPoint("0.7"),
-                kernelVersion: KERNEL_V3_1,
-            });
-            const signature = await kernelAccount?.signTypedData(payload);
+            const signature = await withTimeout(
+                kernelAccount.account.signTypedData(payload),
+                PASSKEY_TIMEOUT_MS,
+                "Signing the transaction",
+            );
             return {
                 success: true,
                 signature: signature,
@@ -171,6 +152,80 @@ export class SigningService {
                 error: error.message || "An unexpected error occurred",
             };
         }
+    }
+
+    // buildKernelAccount resolves the passkey session, wallet and ZeroDev kernel account that
+    // both signing methods need. It is called from inside their try blocks: the passkey and
+    // wallet steps can reject (a dismissed WebAuthn dialog rejects) and previously ran outside
+    // any handler, so the rejection escaped to the click handler as an unhandled rejection and
+    // the caller never saw a result at all.
+    private async buildKernelAccount(
+        settings: NonNullable<SettingsService["privateSettings"]>,
+        accountInfo: NonNullable<SettingsService["accountInfo"]>,
+    ): Promise<{success: true; account: any} | {success: false; error: string}> {
+        const {turnkeyApiUrl, turnkeyOrgId, turnkeyRpId} = settings;
+        const {subOrganizationId} = accountInfo;
+
+        const turnkeyClient = await withTimeout(
+            this.getTurnkeyClient(turnkeyApiUrl, turnkeyRpId, turnkeyOrgId, subOrganizationId),
+            PASSKEY_TIMEOUT_MS,
+            "Passkey authorization",
+        );
+
+        if (!turnkeyClient) {
+            return {
+                success: false,
+                error: "Failed to get turnkey client"
+            };
+        }
+
+        const wallet = await withTimeout(
+            this.getTurnkeyWallet(turnkeyClient, subOrganizationId),
+            NETWORK_TIMEOUT_MS,
+            "Wallet lookup",
+        );
+
+        const turnkeyAccount = await createAccount({
+            client: turnkeyClient,
+            organizationId: accountInfo.subOrganizationId,
+            signWith: wallet,
+        });
+
+        const publicClient = createPublicClient({
+            transport: http(settings.rpcUrl),
+            chain: settings.environment === 'prod' ? polygon : polygonAmoy,
+        });
+
+        const ecdsaValidator = await withTimeout(
+            signerToEcdsaValidator(publicClient, {
+                signer: turnkeyAccount,
+                entryPoint: getEntryPoint("0.7"),
+                kernelVersion: KERNEL_V3_1
+            }),
+            NETWORK_TIMEOUT_MS,
+            "Validator setup",
+        );
+
+        const account = await withTimeout(
+            createKernelAccount(publicClient, {
+                plugins: {
+                    sudo: ecdsaValidator,
+                },
+                entryPoint: getEntryPoint("0.7"),
+                kernelVersion: KERNEL_V3_1,
+            }),
+            NETWORK_TIMEOUT_MS,
+            "Account setup",
+        );
+
+        if (!account) {
+            return {
+                success: false,
+                error: "Failed to build signing account",
+            };
+        }
+
+        return {success: true, account};
     }
 
     public saveSession({ credentialBundle, privateKey }:{ credentialBundle: string; privateKey: string; }) {


### PR DESCRIPTION
## Description

Three vehicles failed to transfer in prod with no error on screen, no `POST /vehicle/transfer` in the proxy logs, and no River job enqueued. The oracle logged nothing because it was never asked to do anything — the flow died client-side between the prepare `GET` and the submit `POST`.

Two bugs in the signing path produce exactly that symptom, and together they make a failed transfer indistinguishable from one the user never started.

**1. The passkey step ran outside the try/catch.** `getTurnkeyClient` and `getTurnkeyWallet` were called before the `try` in both `signUserOperation` and `signTypedData`. `getTurnkeyClient` is what triggers the WebAuthn prompt (`createReadWriteSession`), and a dismissed passkey dialog *rejects*. That rejection escaped the handler, propagated up through `signTransferData` → `transferVehicle` → `confirmTransfer`, and `confirmTransfer` is invoked straight from a click handler with no `catch`. Nothing caught it, so `processing` stayed `true` and the modal spun forever showing neither an error nor any sign it had stopped.

**2. Nothing in the chain has a deadline.** WebAuthn can sit unresolved indefinitely, and the Turnkey and RPC fetches set no timeout. Even without a rejection, the caller's promise may simply never settle — same invisible outcome.

### Changes made

**`web/src/services/signing-service.ts`**

- Extract the shared setup (passkey session → wallet → Turnkey account → ECDSA validator → kernel account) into `buildKernelAccount`, called from **inside** each method's `try`. Both signing methods used a near-identical preamble; sharing it keeps the two from drifting apart again and guarantees both get the same protection.
- Add `withTimeout` and bound every step: `PASSKEY_TIMEOUT_MS` (120s) for the steps that can show a passkey prompt, `NETWORK_TIMEOUT_MS` (30s) for the pure network steps. The underlying work is not cancellable (WebAuthn and `fetch` both keep running), so this bounds what the *caller* waits for rather than aborting the operation.
- State the public return type explicitly as `SigningResult` so callers can keep reading `.signature` and `.error` off one value; `buildKernelAccount`'s discriminated union stays internal.

**`web/src/elements/transfer-modal-element.ts`**

- Wrap `confirmTransfer` in `try/catch/finally` so a *thrown* error reaches the user and `processing` is always reset. The early-return `processing = false` assignments are now redundant and were removed in favour of the `finally`.
- Replace the empty-wallet `alert()` with an inline error, matching how every other failure in this modal is reported.

### Note on an adjacent bug (not changed)

`confirmTransfer` has `if (result.error.toLowerCase().includes('timeout'))`, intended to catch the status-poll timeout. The actual message is `"Transfer operation timed out"` — no substring `"timeout"` — so that branch is already dead and the raw error is shown instead. Left alone deliberately: fixing it would make the modal close with a reassuring message where it currently shows the error, which runs against the point of this PR. Worth a separate look.

The new timeout messages read `"... timed out after Ns"`, so they also do not match that branch and are surfaced verbatim.

### Testing

- `npx tsc --noEmit` — clean (verified the baseline was clean first, so no pre-existing errors are being masked)
- `npx eslint` on both changed files — 0 errors (warnings are the files' pre-existing `any`/`console` style)
- `npm run build` — succeeds

Not yet exercised against a live passkey prompt; the intent is to deploy and retry the failing transfer with both this and DIMO-Network/kaufmann-oracle#194 in place, so the next attempt reports *something* whichever side it fails on.
