### PR TITLE
feat: explain the missing permission on click instead of hiding the action

### DIFF
--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -81,6 +81,21 @@ export class TransferModalElement extends BaseOnboardingElement {
           .shared-account-text {
             flex: 1 1 auto;
           }
+          .permission-denied-banner {
+            background-color: #fff7ed;
+            border: 1px solid #fed7aa;
+            border-left: 4px solid #ea580c;
+            border-radius: 4px;
+            padding: 12px;
+            margin-bottom: 16px;
+            color: #7c2d12;
+            font-size: 13px;
+            line-height: 1.45;
+          }
+          .permission-denied-banner strong {
+            display: block;
+            margin-bottom: 4px;
+          }
         `
     ];
     @property({attribute: true, type: Boolean})
@@ -100,6 +115,14 @@ export class TransferModalElement extends BaseOnboardingElement {
     // POST /v1/vehicle/transfer/shared instead of asking the wallet for a passkey signature.
     @property({attribute: true, type: Boolean})
     public useSharedAccountFlow = false;
+
+    // Set when the connected user lacks manage_vehicles and this transfer would take the
+    // shared-account path. The modal still opens: the action is real and available to the
+    // tenant, so the useful thing to show is why *this* user cannot run it, rather than a
+    // button that silently vanished. The backend refuses it regardless — this only moves the
+    // refusal to click time instead of after the form is filled in.
+    @property({attribute: false, type: Boolean})
+    public permissionDenied = false;
 
     @state()
     private walletAddress = "";
@@ -185,6 +208,12 @@ export class TransferModalElement extends BaseOnboardingElement {
                                     </span>
                                 </div>
                             ` : nothing}
+                            ${this.permissionDenied ? html`
+                                <div class="permission-denied-banner" role="alert">
+                                    <strong>${msg('You don\'t have permission to transfer this vehicle.')}</strong>
+                                    ${msg('This vehicle is owned by a shared account, so transferring it acts on someone else\'s behalf and needs the manage_vehicles permission. Ask an administrator to grant it.')}
+                                </div>
+                            ` : nothing}
                             ${this.errorMessage ? html`
                                 <div style="background-color: #fee; border: 1px solid #fcc; border-radius: 4px; padding: 12px; margin-bottom: 16px; color: #c33;">
                                     ${this.errorMessage}
@@ -221,7 +250,7 @@ export class TransferModalElement extends BaseOnboardingElement {
                                         <button type="button" 
                                                 class="action-btn ${this.processing ? 'processing' : ''}" 
                                                 @click=${() => this.confirmTransfer('wallet')}
-                                                ?disabled=${!this.walletAddress.trim() || this.processing}>
+                                                ?disabled=${!this.walletAddress.trim() || this.processing || this.permissionDenied}>
                                             ${this.processing ? msg('Processing...') : msg('Transfer by Wallet')}
                                         </button>
                                     </form>
@@ -264,7 +293,7 @@ export class TransferModalElement extends BaseOnboardingElement {
                                         <button type="button"
                                                 class="action-btn ${this.processing ? 'processing' : ''}"
                                                 @click=${() => this.confirmTransfer('email')}
-                                                ?disabled=${!this.email.trim() || this.processing || this.isCheckingEmail || !!this.emailLookupError}>
+                                                ?disabled=${!this.email.trim() || this.processing || this.isCheckingEmail || !!this.emailLookupError || this.permissionDenied}>
                                             ${this.processing ? msg('Processing...') : msg('Transfer by Email')}
                                         </button>
                                     </form>
@@ -398,6 +427,13 @@ export class TransferModalElement extends BaseOnboardingElement {
     }
 
     async confirmTransfer(transferType: 'wallet' | 'email') {
+        // The buttons are disabled in this state, so reaching here means the property changed
+        // after render or the click came from somewhere else. Refuse rather than let the
+        // request go out only to be refused by the backend.
+        if (this.permissionDenied) {
+            return;
+        }
+
         this.processing = true;
         this.errorMessage = "";
         this.statusMessage = "";

--- a/web/src/elements/vehicle-list-element.ts
+++ b/web/src/elements/vehicle-list-element.ts
@@ -4,6 +4,7 @@ import {repeat} from 'lit/directives/repeat.js';
 import {customElement, property, state} from "lit/decorators.js";
 import {Vehicle} from "@datatypes//vehicle.ts";
 import {ApiService} from "@services/api-service.ts";
+import {IdentityService} from "@services/identity-service.ts";
 import {globalStyles} from "../global-styles.ts";
 
 interface VehiclesResponse {
@@ -50,6 +51,10 @@ export class VehicleListElement extends LitElement {
     @state()
     private exporting: boolean = false;
 
+    // The connected user's capabilities, shared with every row so each one does not refetch.
+    @state()
+    private permissions: string[] = [];
+
     private searchDebounce?: number;
 
 
@@ -76,7 +81,20 @@ export class VehicleListElement extends LitElement {
         // Listen for bubbling item change events from row items
         this.addEventListener('item-changed', this.handleItemChanged as EventListener);
         this.addEventListener('item-deleted', this.handleItemDeleted as EventListener);
+        // Fetched once here rather than per row: every row asks the same question, and the
+        // list can be 500 items. Not awaited alongside the vehicles because a failure to
+        // resolve permissions must not stop the list rendering — it only means nothing is
+        // gated client-side, which the backend still refuses.
+        void this.loadPermissions();
         await this.loadVehicles();
+    }
+
+    private async loadPermissions() {
+        try {
+            this.permissions = await IdentityService.getInstance().getUserPermissions();
+        } catch (e) {
+            console.error('Failed to load permissions for vehicle list', e);
+        }
     }
 
     disconnectedCallback(): void {
@@ -244,7 +262,7 @@ export class VehicleListElement extends LitElement {
                         </thead>
                         <tbody>
                         ${repeat(this.filteredItems, (item) => item.id, (item) =>
-                                html`<vehicle-list-item-element style="display: contents" .item=${item}></vehicle-list-item-element>`)}
+                                html`<vehicle-list-item-element style="display: contents" .item=${item} .permissions=${this.permissions}></vehicle-list-item-element>`)}
                         </tbody>
                     </table>
                 </div>

--- a/web/src/elements/vehicle-list-item-element.ts
+++ b/web/src/elements/vehicle-list-item-element.ts
@@ -7,6 +7,23 @@ import {BaseOnboardingElement} from "@elements/base-onboarding-element.ts";
 import {delay} from "@utils/utils.ts";
 import {globalStyles} from "../global-styles.ts";
 
+// Capability required by the backend for the shared-account routes — transfer, disconnect and
+// delete performed by the tenant's signer on an account it does not own.
+const MANAGE_VEHICLES = 'manage_vehicles';
+
+// Shown when the user may not run one of those. The buttons stay visible and clickable on
+// purpose: the action is real and the tenant can perform it, so the useful thing to say is
+// which permission is missing, rather than removing the control and leaving no explanation.
+//
+// Written out per action rather than interpolated: lit-localize needs the `str` tag to
+// extract a template with expressions, and a translated sentence cannot be assembled from an
+// English verb anyway.
+const disconnectDeniedMessage = () =>
+    msg("You don't have permission to disconnect this vehicle. It is owned by a shared account, so disconnecting it acts on someone else's behalf and needs the manage_vehicles permission. Ask an administrator to grant it.");
+
+const deleteDeniedMessage = () =>
+    msg("You don't have permission to delete this vehicle. It is owned by a shared account, so deleting it acts on someone else's behalf and needs the manage_vehicles permission. Ask an administrator to grant it.");
+
 interface SyncFromIdentityResult {
     tokenId: number;
     ownerChanged: boolean;
@@ -46,6 +63,13 @@ export class VehicleListItemElement extends BaseOnboardingElement {
 
     @property({attribute: true})
     public item?: Vehicle;
+
+    // The connected user's capabilities, fetched once by the list rather than per row.
+    // Advisory only: the backend is authoritative and refuses these operations on its own.
+    // Empty is the safe default — before the list resolves them nothing is gated, and the
+    // server still refuses, so a slow fetch cannot hand anyone access they lack.
+    @property({attribute: false})
+    public permissions: string[] = [];
 
     @state()
     private connectionProcessing = false;
@@ -194,6 +218,16 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         return !item.isCurrentUserOwner && !!item.isSharedAccountSigner;
     }
 
+    // lacksManageVehicles reports whether this action would take the shared-account path
+    // without the capability the backend now requires for it.
+    //
+    // The shared-account path is the only one gated. Owning the vehicle already authorises
+    // the passkey flows — those refuse anyone who isn't the on-chain owner — so requiring the
+    // capability there would block people from acting on their own vehicles.
+    private lacksManageVehicles(item: Vehicle): boolean {
+        return this.isSharedSigner(item) && !this.permissions.includes(MANAGE_VEHICLES);
+    }
+
     canDisconnect(item: Vehicle): boolean {
         if (!item.isCurrentUserOwner && !this.isSharedSigner(item)) return false;
         return [ConnectionStatus.CONNECTED, ConnectionStatus.DISCONNECTION_FAILED].includes(this.getConnectionStatus(item));
@@ -263,6 +297,13 @@ export class VehicleListItemElement extends BaseOnboardingElement {
             return;
         }
 
+        // Gated before the confirm: asking someone to confirm an action they cannot run and
+        // then refusing them is worse than saying so up front.
+        if (this.lacksManageVehicles(this.item)) {
+            this.openErrorModal(disconnectDeniedMessage(), msg('Permission required'));
+            return;
+        }
+
         if (!confirm(msg("Are you sure you want to disconnect the vehicle?"))) {
             return;
         }
@@ -286,6 +327,11 @@ export class VehicleListItemElement extends BaseOnboardingElement {
 
     async deleteVehicle() {
         if (!this.item) {
+            return;
+        }
+
+        if (this.lacksManageVehicles(this.item)) {
+            this.openErrorModal(deleteDeniedMessage(), msg('Permission required'));
             return;
         }
 
@@ -337,6 +383,9 @@ export class VehicleListItemElement extends BaseOnboardingElement {
         // The connected wallet isn't the literal owner but our tenant can sign for the
         // owning kernel — modal will use the server-signed shared-account flow.
         modal.useSharedAccountFlow = !!(this.item && !this.item.isCurrentUserOwner && this.item.isSharedAccountSigner);
+        // Opened either way — the modal explains the missing permission rather than the
+        // button disappearing with no reason given.
+        modal.permissionDenied = !!(this.item && this.lacksManageVehicles(this.item));
 
         // Add event listener for modal close
         modal.addEventListener('modal-closed', () => {


### PR DESCRIPTION
## Description

Companion to DIMO-Network/kaufmann-oracle#196, which now requires `manage_vehicles` on the shared-account routes.

Without anything on this side, a member without the capability fills in the entire transfer form and is refused at submit — or clicks disconnect/delete, confirms a destructive action, and is refused after confirming. Hiding the buttons avoids that but leaves no explanation and makes a real, tenant-available action look like it does not exist.

So the buttons stay visible and clickable, and the refusal moves to click time with the reason attached.

### Behaviour

| Action | Before | After |
|---|---|---|
| Transfer | Modal opens, form fills, `403` on submit | Modal opens with a banner naming the permission; both transfer buttons disabled |
| Disconnect | `confirm()`, then `403` | "Permission required" modal **before** the confirm |
| Delete | `confirm()`, then `403` | "Permission required" modal **before** the confirm |

Disconnect and delete have no modal of their own, so they reuse the existing `error-modal-element` rather than introducing a second pattern. Showing it before the confirm is deliberate: asking someone to confirm an action they cannot run and then refusing them is worse than saying so up front.

### Only the shared-account path is gated

`lacksManageVehicles` requires `isSharedSigner(item)`, matching exactly what the backend gates. The passkey flows are already self-authorising — the server refuses anyone who is not the on-chain owner — so requiring the capability there would stop people acting on their own vehicles.

### Permissions are fetched once, and fail open client-side

`vehicle-list-element` loads them in `connectedCallback` and passes them to each row; the list can be 500 items and every row asks the same question. The call is deliberately **not** awaited alongside the vehicles, so a failure to resolve permissions cannot stop the list rendering.

The property defaults to `[]`, which gates nothing. That is the safe default here precisely because this check is advisory — a slow or failed fetch leaves the server to refuse, and can never hand anyone access they lack.

### Known limitation

This reads `GET /v1/permissions`, which still serves `access_tenants`, while enforcement reads the tenancy service. The two are kept in step by the paired backfills in kaufmann-oracle#196 and fleet-tenancy-api#21. Drift would show the banner to someone the server would in fact allow — never the reverse, so it cannot become a way through. It stops being a concern once `CheckAccess` moves to the tenancy service, which is the same per-endpoint-capability migration this work belongs to.

### Localization

The new strings are **not** committed to `xliff/es.xlf`. `lit-localize extract` rewrites the whole file and would have pulled in 57 strings from unreleased work in progress along with my 3. They fall back to English in Spanish until extraction is run against a clean tree. Verified they extract cleanly (`Extracted 878 messages`) — the messages avoid interpolation, which `msg()` cannot extract without the `str` tag and which cannot be translated from an English verb stem anyway.

### Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on all three files — 0 errors (warnings are the files' pre-existing `any`/`console` style)
- `npm run build` — succeeds

Not exercised against a live session; the gating logic is pure and driven by two inputs (`isSharedSigner`, `permissions`).
