### PR TITLE
feat: show VIN and token id in the transfer modal title

### DIFF
--- a/web/src/elements/transfer-modal-element.ts
+++ b/web/src/elements/transfer-modal-element.ts
@@ -16,6 +16,27 @@ export interface AccountData {
 export class TransferModalElement extends BaseOnboardingElement {
     static styles = [ globalStyles,
         css`
+          /* The header is a flex row with the close button pushed to the far end. Grouping
+             the heading and the identifiers keeps that layout intact, and min-width: 0 lets
+             the group shrink rather than shoving the close button off the edge. */
+          .modal-title-group {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            min-width: 0;
+          }
+          /* .modal-header sets font-weight: bold, hence the explicit normal here. */
+          .modal-title-meta {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            gap: 10px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 12px;
+            font-weight: normal;
+            color: #6b7280;
+            overflow-wrap: anywhere;
+          }
           .transfer-options {
             display: grid;
             grid-template-columns: 1fr;
@@ -196,7 +217,19 @@ export class TransferModalElement extends BaseOnboardingElement {
             <div class="modal-overlay" @click=${this.closeModal}>
                 <div class="modal-content" @click=${(e: Event) => e.stopPropagation()}>
                     <div class="modal-header">
-                        <h3>${msg('Transfer Vehicle')}</h3>
+                        <div class="modal-title-group">
+                            <h3>${msg('Transfer Vehicle')}</h3>
+                            ${this.vehicleVin || this.tokenId ? html`
+                                <span class="modal-title-meta">
+                                    ${this.vehicleVin ? html`
+                                        <span title=${msg('VIN')}>${this.vehicleVin}</span>
+                                    ` : nothing}
+                                    ${this.tokenId ? html`
+                                        <span title=${msg('Vehicle token ID')}>#${this.tokenId}</span>
+                                    ` : nothing}
+                                </span>
+                            ` : nothing}
+                        </div>
                         <button type="button" class="modal-close" @click=${this.closeModal}>×</button>
                     </div>
                         <div class="modal-body">


### PR DESCRIPTION
## Description

The transfer modal named neither the vehicle nor the token. Transferring moves ownership irreversibly, so once the modal was open there was nothing to check the intended vehicle against — which matters most when working through several in a row, as happened today with three VINs going to the same wallet.

Adds the VIN and token id under the heading:

```
Transfer Vehicle
LSFAM11A1SA055763   #192401                                    ×
```

### Notes

- The header is a flex row with the close button pushed to the far end, so the heading and identifiers go in a column group to leave that layout intact. `min-width: 0` lets the group shrink rather than shoving the close button off the edge.
- Both values are guarded. An unminted vehicle (`tokenId` defaults to `0`) or a missing VIN renders the heading alone rather than a stray separator.
- Monospace for the identifiers — a 17-character VIN gets read character by character when comparing it against a record.
- `.modal-header` sets `font-weight: bold`, so the meta line sets `normal` explicitly.
- `title` attributes label each value, since `#192401` on its own does not say "token id".

No logic changes; presentation only.

### Branching

Branched from `origin/main` (`944309e`) in a separate git worktree, so the parallel work on `feat/customers-console` in the primary checkout was not disturbed. Touches one file, which that branch does not.

### Testing

- `npx tsc --noEmit` — clean
- `npx eslint src/elements/transfer-modal-element.ts` — 0 errors (10 warnings, all pre-existing `any`/`console` style in this file)
- `npm run build` — succeeds

Not rendered in a live session; the change is markup and CSS with both values guarded.
