### PR TITLE
feat: proxy routes for the Customers console's live endpoints

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -197,6 +197,17 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	// settings the app needs to operate, pulled from config / env vars
 	oracleApp.Get("/settings", settingsCtrl.GetSettings) // todo some of these are oracle specific
 
+	// Operator console: customer tenants. These reach fleet-tenancy-api through
+	// the oracle, which authenticates to it with a developer licence this app
+	// does not have. Plain proxies — the oracle checks the user's capability.
+	oracleApp.Get("/tenancy/operator", genericProxyCtrl.Proxy)
+	oracleApp.Patch("/tenancy/operator", genericProxyCtrl.Proxy)
+	oracleApp.Get("/tenancy/customers", genericProxyCtrl.Proxy)
+	oracleApp.Post("/tenancy/customers", genericProxyCtrl.Proxy)
+	oracleApp.Get("/tenancy/customers/:customerID", genericProxyCtrl.Proxy)
+	oracleApp.Patch("/tenancy/customers/:customerID", genericProxyCtrl.Proxy)
+	oracleApp.Get("/tenancy/customers/:customerID/members", genericProxyCtrl.Proxy)
+
 	oracleApp.Get("/tenants", genericProxyCtrl.Proxy)
 	oracleApp.Post("/tenant", genericProxyCtrl.Proxy)
 	oracleApp.Get("/tenant/settings", genericProxyCtrl.Proxy)

--- a/web/src/services/tenancy-service.ts
+++ b/web/src/services/tenancy-service.ts
@@ -23,6 +23,21 @@ export type { OperatorFleetVehicle } from "@services/tenancy-stub.ts";
 // lands, change STUB_BY_DEFAULT to false; when the stub is no longer wanted,
 // delete tenancy-stub.ts and the branch in call().
 //
+// THE FLAG IS ALL-OR-NOTHING, AND THE BACKEND IS ARRIVING IN SLICES. As of the
+// tenants slice these are served for real:
+//
+//   GET/PATCH  /tenancy/operator
+//   GET/POST   /tenancy/customers
+//   GET/PATCH  /tenancy/customers/{id}
+//   GET        /tenancy/customers/{id}/members
+//
+// while member provisioning and everything under /vehicles are still fixtures.
+// So flipping the flag today gives a working customer list, creation, settings
+// and users table, and a 404 on provisioning or assigning a vehicle. That is
+// why the default is still the stub: a half-live console is harder to reason
+// about than an obviously fake one. Flip the default once the remaining slices
+// land, not before.
+//
 // ROUTING. Live mode calls /tenancy/* under the oracle prefix, so a request
 // leaves the browser as
 //
@@ -204,6 +219,12 @@ export class TenancyService {
     if (this.isStubbed()) return stubbed();
     return this.api.callApi<T>(method, `/tenancy${path}`, body, true, true, true);
   }
+
+  // The customer id the console works in terms of is the tenant id. The two
+  // paths below differ because the operator is implied by the caller's own
+  // Tenant-Id header rather than named in the URL — the console never selects
+  // an operator, it *is* one.
+
 
   // CUSTOMERS
 


### PR DESCRIPTION
-- for agents

## Description

Registers `/tenancy/*` under the oracle prefix, so a Customers console request goes **b2b → kaufmann → fleet-tenancy-api**. Plain proxies — the oracle checks the user's capability, and this app holds no developer licence with which to authenticate to the tenancy service itself.

**Stacked on #171** (the console itself). Base is `feat/customers-console`, so review that first; the diff here is only the wiring.

Needs **fleet-tenancy-api#23** and **kaufmann-oracle#198**.

---
**Model used:** Claude Opus 5 (1M context)
**Agent:** Claude Code
**Mode:** Auto mode

**Prompt:**
> own set of PRs, let's continue

---

### Changes made:

- Proxy routes for `/tenancy/operator` and `/tenancy/customers[/:id[/members]]`.
- A note in `tenancy-service.ts` recording exactly which endpoints are live.

### The stub flag is all-or-nothing, and the backend is arriving in slices

Flipping `localStorage.tenancyStub = 'false'` today gives a working customer list, creation, settings and users table — and a **404 on provisioning a user or assigning a vehicle**, which are the next two slices.

So the default stays on the stub. A half-live console is harder to reason about than an obviously fake one, and the `<stub-data-banner>` telling you the data isn't real is more useful than a console where some of it is and some of it isn't. Flip the default when the remaining slices land, not before.
