### PR TITLE
fix: modal footers were clipped once the body outgrew the dialog

### DIFF
--- a/web/src/global-styles.ts
+++ b/web/src/global-styles.ts
@@ -826,7 +826,14 @@ export const globalStyles = css`
         display: flex;
     }
 
-    /* Dialog container */
+    /* Dialog container.
+     *
+     * The flex column is what makes "header/footer stick, body scrolls" true.
+     * Without it the three children stack at their natural heights, the body
+     * grows with its content, and the footer is pushed past max-height and
+     * clipped by overflow:hidden — invisible and unreachable. That is exactly
+     * what happened to the onboarding confirmation dialog past ~4 vehicles:
+     * Cancel and Confirm were rendered but unclickable. */
     .modal-content, .modal {
         background: #fff;
         border: 1px solid #000;
@@ -835,7 +842,9 @@ export const globalStyles = css`
         max-width: 800px;
         width: min(90vw, 800px);
         max-height: 90vh;
-        overflow: hidden; /* header/footer stick, body scrolls */
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
     }
 
     .modal-header {
@@ -873,10 +882,21 @@ export const globalStyles = css`
         border-color: #ccc;
     }
 
+    /* The body is the only part that scrolls, and it takes whatever height the
+     * header and footer leave. min-height:0 is load-bearing: a flex item
+     * defaults to min-height:auto, which refuses to shrink below its content
+     * and would push the footer out again. The old max-height of
+     * calc(90vh - 56px) subtracted the header but not the footer, so the
+     * three together always exceeded the container. */
     .modal-body {
         padding: 16px;
         overflow: auto;
-        max-height: calc(90vh - 56px); /* subtract header approx */
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+
+    .modal-header, .modal-footer {
+        flex: 0 0 auto;
     }
 
     .modal-footer {


### PR DESCRIPTION
## Description
Onboarding more than ~4 vehicles opened the confirmation dialog with **Cancelar / Confirmar Registro missing** — rendered, but clipped and unclickable.

**Cause.** `.modal-content` declares `max-height: 90vh; overflow: hidden` with the comment *"header/footer stick, body scrolls"* — but it was never made a flex column, so header/body/footer just stack at their natural heights. `.modal-body` then capped itself at `calc(90vh - 56px)`, subtracting the header but **not** the footer. So the three together always exceeded the container, and `overflow: hidden` clipped the footer away.

**Fix.** Make the dialog the flex column it always claimed to be: body flexes and scrolls, header and footer stay fixed. `min-height: 0` on the body is load-bearing — a flex item defaults to `min-height: auto` and refuses to shrink below its content, which would push the footer straight back out.

This is a **global** fix because all 17 modal elements share these classes and all had the bug. Notably `edit-device-definition-modal-element` already carried exactly this fix locally (flex column + `flex: 1; overflow-y: auto`), so this generalises a proven remedy rather than inventing one; its local override is now redundant but harmless. The other two local overrides only set widths and are unaffected.

**Verified** in a browser against a reproduction with 12 vehicles (3× the reported threshold): the body scrolls internally and both buttons stay pinned and clickable.

---
**Model used:** Claude Fable 5
**Agent:** Claude Code
**Mode:** Auto mode

**Prompt:** The issue happens when you try onboarding the vehicles that are selected in the checklist pending onboard table. The modal that opens hides the bottom footer buttons if you select more than say 4 vehicles.

---

### Changes made:
- `web/src/global-styles.ts`: `.modal-content, .modal` gains `display: flex; flex-direction: column`; `.modal-body` swaps its header-only `max-height` for `flex: 1 1 auto; min-height: 0`; `.modal-header, .modal-footer` pinned with `flex: 0 0 auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RifTN8ZabDWb1hW7XtBRcQ