### PR TITLE
feat: BFF routes for vehicle memberships — the console goes live

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -213,6 +213,15 @@ func App(settings *config.Settings, logger *zerolog.Logger, commitHash string) *
 	oracleApp.Get("/tenancy/customers/:customerID/vehicles", genericProxyCtrl.Proxy)
 	oracleApp.Post("/tenancy/customers/:customerID/vehicles", genericProxyCtrl.Proxy)
 	oracleApp.Delete("/tenancy/customers/:customerID/vehicles/:tokenID", genericProxyCtrl.Proxy)
+	// Vehicle memberships — what the customer has paid for, per vehicle, as
+	// opposed to the vehicles above, which are what they may see. Registered
+	// one by one like everything else here: the proxy has no catch-all, and an
+	// unregistered path 404s with proxy_route_not_registered.
+	oracleApp.Get("/tenancy/customers/:customerID/memberships", genericProxyCtrl.Proxy)
+	oracleApp.Post("/tenancy/customers/:customerID/memberships", genericProxyCtrl.Proxy)
+	oracleApp.Post("/tenancy/customers/:customerID/memberships/:membershipID/move", genericProxyCtrl.Proxy)
+	oracleApp.Post("/tenancy/customers/:customerID/memberships/:membershipID/renew", genericProxyCtrl.Proxy)
+	oracleApp.Delete("/tenancy/customers/:customerID/memberships/:membershipID", genericProxyCtrl.Proxy)
 
 	oracleApp.Get("/tenants", genericProxyCtrl.Proxy)
 	oracleApp.Post("/tenant", genericProxyCtrl.Proxy)


### PR DESCRIPTION
Step 5 of `fleet-tenancy-api docs/plans/02-vehicle-memberships.md`, and the last hop in the chain: browser → here → kaufmann → fleet-tenancy-api.

Completes the stack with **fleet-tenancy-api#37** (endpoints) and **kaufmann-oracle#208** (proxy).

## No frontend change, deliberately

#179 built the console against the stub speaking exactly this protocol, so registering these five routes is the whole of what takes it live. Same as how the provisioning routes landed in #175 — the views needed no edit there either. That's the payoff of having sequenced the UI first.

```
GET    /oracle/:oracleID/tenancy/customers/:customerID/memberships
POST   /oracle/:oracleID/tenancy/customers/:customerID/memberships
POST   /oracle/:oracleID/tenancy/customers/:customerID/memberships/:membershipID/move
POST   /oracle/:oracleID/tenancy/customers/:customerID/memberships/:membershipID/renew
DELETE /oracle/:oracleID/tenancy/customers/:customerID/memberships/:membershipID
```

Registered individually because the proxy has no catch-all: an unregistered path 404s with `proxy_route_not_registered`, which is exactly what the memberships panel has been rendering as *"Memberships aren't available on this environment yet"*. These routes are what stops it saying that.

## Testing

`go build`, `go vet` and `go test ./...` all pass. The proxy tests cover `ProxyRequest` behaviour rather than the route table, so no test changes were needed.

## Deploy order

Standing rule, and it matters here: **fleet-tenancy-api#37 → kaufmann-oracle#208 → this**. A caller shipped ahead of its endpoints turns every membership action into a 502.

Enforcement is off for every tenant on arrival, so even with all three deployed nothing changes for any customer until an operator turns it on per customer.

## Follow-up

The route inventory comment at the top of `web/src/services/tenancy-service.ts` (added in #179) lists memberships under "NOT yet served". That's accurate until this deploys and stale afterwards — worth correcting when #179 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZiCq7vZiC2L5MzZq4tVw5