### PR TITLE
fix: reload the pending list when a vehicle is deleted

### DIFF
--- a/web/src/elements/add-vin-element.ts
+++ b/web/src/elements/add-vin-element.ts
@@ -414,15 +414,7 @@ export class AddVinElement extends BaseOnboardingElement {
                 this.vinsBulk = "";
                 this.requestUpdate();
 
-                // Clear selection and reload pending vehicles component. It renders in
-                // this element's shadow root, so look it up via renderRoot —
-                // this.querySelector only sees light-DOM children and finds nothing.
-                const pendingVehiclesElement = this.renderRoot.querySelector('pending-vehicles-element') as any;
-                if (pendingVehiclesElement) {
-                    pendingVehiclesElement.clearSelection();
-                    // Reload the pending vehicles list after successful onboarding
-                    await pendingVehiclesElement.loadPendingVehicles();
-                }
+                await this.reloadPendingVehicles(true);
             } catch (e) {
                 this.displayFailure(msg("failed to onboard vins: ") + e);
             }
@@ -440,6 +432,24 @@ export class AddVinElement extends BaseOnboardingElement {
             bubbles: true,
             composed: true
         }));
+    }
+
+    // reloadPendingVehicles refreshes the pending list, optionally clearing its selection.
+    // Public because the onboarding view calls it when a vehicle is deleted: deleting burns
+    // the NFT and the oracle then returns the record to the pending pool, so the device
+    // reappears here — but only if something asks for the list again.
+    //
+    // The component renders in this element's shadow root, so it must be looked up via
+    // renderRoot; this.querySelector only sees light-DOM children and finds nothing.
+    public async reloadPendingVehicles(clearSelection = false) {
+        const pendingVehiclesElement = this.renderRoot.querySelector('pending-vehicles-element') as any;
+        if (!pendingVehiclesElement) {
+            return;
+        }
+        if (clearSelection) {
+            pendingVehiclesElement.clearSelection();
+        }
+        await pendingVehiclesElement.loadPendingVehicles();
     }
 
     // todo i think we pass in an array of SacdInput in here and have something that builds the sacd inputs

--- a/web/src/views/onboarding.ts
+++ b/web/src/views/onboarding.ts
@@ -13,7 +13,7 @@ export class OnboardingView extends LitElement {
         <!-- No item-changed binding on vehicle-list-element: it reloads itself on its
              own rows' events, which then bubble here — a binding would reload twice. -->
         <add-vin-element @item-changed=${this.handleItemChanged}></add-vin-element>
-        <vehicle-list-element></vehicle-list-element>
+        <vehicle-list-element @item-deleted=${this.handleItemDeleted}></vehicle-list-element>
     `;
   }
 
@@ -26,8 +26,24 @@ export class OnboardingView extends LitElement {
         }
     }
 
+    private async reloadPendingVehicles() {
+        const addVinElement = this.renderRoot.querySelector('add-vin-element') as any;
+        if (addVinElement && addVinElement.reloadPendingVehicles) {
+            await addVinElement.reloadPendingVehicles();
+        }
+    }
+
     private async handleItemChanged() {
         // When items are added/changed, reload the vehicle list
         await this.reloadVehicleList();
+    }
+
+    // Deleting a vehicle burns its NFT, and the oracle then returns the record to the
+    // pending pool so it can be onboarded again without a separate Reset Onboarding step.
+    // The row removes itself from the vehicle list locally, but the pending list above it
+    // only reloads if asked — without this the device would not reappear until a page
+    // refresh, which reads as the delete having lost it.
+    private async handleItemDeleted() {
+        await this.reloadPendingVehicles();
     }
 }


### PR DESCRIPTION
## Description

Pairs with **DIMO-Network/kaufmann-oracle#219**, which makes deleting a vehicle return its record to the pending pool automatically instead of parking it at `BurnVehicleSuccess` and making the operator press **Reset Onboarding**.

With that change the device reappears as pending immediately — but the pending list only reloads when something asks it to. Without this PR the vehicle would disappear from the minted list (which drops the row locally) and show up **nowhere** until a page refresh, reading as though the delete had lost it. That's the same class of bug as #178.

### Changes

- `web/src/views/onboarding.ts` — listens for `item-deleted`, which already bubbles from the row (`composed: true`), and refreshes the pending list.
- `web/src/elements/add-vin-element.ts` — the shadow-root lookup it was doing inline after a successful mint becomes a public `reloadPendingVehicles(clearSelection?)`, so both paths share one implementation instead of each reaching through `renderRoot` themselves.

No new user-facing strings, so no localization changes.

### Testing

- `npx tsc --noEmit` clean
- `npx eslint` — 0 errors (warnings pre-existing)
- `npm run build` succeeds

Merge alongside kaufmann-oracle#219 — on its own this is a harmless no-op refresh, and without it #219's improvement is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrujMmKrtrsFfj2EbQPJhd
